### PR TITLE
0.0.5: stability fixes (malformed targets, cleanup failure aggregation, dep bumps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to LinkSiren will be documented in this file. The
+format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.5] - 2026-06-26
+### Fixed
+- `process_targets` no longer crashes on blank or whitespace-only lines in target files. Offending lines (and malformed UNC entries) are logged and skipped instead.
+- `handle_cleanup` now accumulates per-host delete failures across the whole target list. Previously it reassigned the failure list on each iteration, silently dropping failures from earlier hosts.
+
+### Changed
+- Bumped runtime minimums: `impacket >= 0.12.0`, `tqdm >= 4.68.0`.
+- Pinned dev tooling minimums (`black >= 25`, `ruff >= 0.7`, `pytest >= 8.0`, `coverage >= 7.6`, `isort >= 5.13`, `bumpver >= 2024.0`, `pip-tools >= 7.4`).
+- Build requirement bumped to `setuptools >= 80.0.0`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 # pyproject.toml
 
 [build-system]
-requires = ["setuptools>=75.0.0", "wheel"]
+requires = ["setuptools>=80.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "linksiren"
-version = "0.0.4"
+version = "0.0.5"
 description = "Generation, targeted deployment, and scalable cleanup for files that coerce Windows authentication."
 readme = "README.md"
 authors = [{ name = "George Hamilton"}]
@@ -18,13 +18,21 @@ classifiers = [
 ]
 keywords = ["coerce", "pentest", "windows", "authentication", "coercion"]
 dependencies = [
-    "impacket>=0.11.0",
-    "tqdm>=4.67.1"
+    "impacket>=0.12.0",
+    "tqdm>=4.68.0"
 ]
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-dev = ["black", "bumpver", "isort", "pip-tools", "pytest", "coverage", "ruff"]
+dev = [
+    "black>=25.0.0",
+    "bumpver>=2024.0.0",
+    "isort>=5.13.0",
+    "pip-tools>=7.4.0",
+    "pytest>=8.0.0",
+    "coverage>=7.6.0",
+    "ruff>=0.7.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/gjhami/LinkSiren"

--- a/src/linksiren/mode_handlers.py
+++ b/src/linksiren/mode_handlers.py
@@ -197,10 +197,13 @@ def handle_cleanup(args, credentials):
         None
     """
     payloads_not_deleted = []
+    payloads_not_deleted = []
     targets = read_targets(args.targets)
     for target in targets:
         target.connect(credentials)
-        payloads_not_deleted = target.delete_payloads()
+        # Use ``extend`` so failures from earlier hosts aren't dropped on the
+        # floor when iterating multiple targets.
+        payloads_not_deleted.extend(target.delete_payloads())
 
     write_list_to_file(payloads_not_deleted, "payloads_not_deleted.txt", "w")
 

--- a/src/linksiren/pure_functions.py
+++ b/src/linksiren/pure_functions.py
@@ -27,10 +27,25 @@ def process_targets(unc_paths: list):
         ]
         targets = process_targets(unc_paths)
         # targets will contain HostTarget objects with grouped paths by host.
+
+    Blank lines, whitespace-only lines, and malformed UNC entries are
+    skipped with a log message rather than crashing the whole run.
     """
     targets = []
+    logger = logging.getLogger("main_logger")
+
     for unc_path in unc_paths:
-        host, path = parse_target(unc_path)
+        stripped = unc_path.strip() if isinstance(unc_path, str) else unc_path
+        if not stripped:
+            continue
+        try:
+            host, path = parse_target(stripped)
+        except ValueError as e:
+            logger.error(
+                "Skipping malformed target",
+                extra={"path": stripped, "exception": str(e)},
+            )
+            continue
 
         target_handled = False
         for target in targets:
@@ -46,18 +61,25 @@ def process_targets(unc_paths: list):
 
 
 def parse_target(unc_path: str):
-    """
-    Parses a UNC (Universal Naming Convention) path to extract the host and the path.
-    Args:
-        unc_path (str): The UNC path to be parsed. It should be in the format
-        '\\\\host\\path\\to\\resource'.
-    Returns:
-        tuple: A tuple containing the host and the path. The host is the third element in the
-               split path, and the path is the remaining elements joined by backslashes.
-    """
-    host = unc_path.split("\\")[2]
-    path = "\\".join(unc_path.split("\\")[3:])
+    """Split ``\\\\host\\share\\sub\\dir`` into ``(host, "share\\sub\\dir")``.
 
+    The leading ``\\\\`` is required. A bare ``\\\\host`` (no share) yields
+    ``(host, "")``, used downstream as "expand to all shares on this host".
+
+    Raises:
+        ValueError: if ``unc_path`` is empty or not a UNC path.
+    """
+    if not unc_path or not unc_path.startswith("\\\\"):
+        raise ValueError(
+            f"Invalid UNC target {unc_path!r}: expected a path starting with \\\\"
+        )
+
+    # strip the leading "\\" so split() doesn't yield two empty leading elements
+    parts = unc_path[2:].split("\\")
+    host = parts[0]
+    if not host:
+        raise ValueError(f"Invalid UNC target {unc_path!r}: empty host component")
+    path = "\\".join(parts[1:])
     return host, path
 
 


### PR DESCRIPTION
## Summary
Patch for a few bugs.

## Changes
* `process_targets`: tolerate blank, whitespace-only, and malformed UNC entries in targets files instead of raising `IndexError`. Logged and skipped via a clear `ValueError` from `parse_target`.
* `handle_cleanup`: accumulate failures from every host (`payloads_not_deleted.extend(...)`) instead of reassigning on each iteration. Previously, failures from any host except the last were silently dropped from `payloads_not_deleted.txt`.
* Bumped runtime minimums (`impacket >= 0.12.0`, `tqdm >= 4.68.0`, build `setuptools >= 80.0.0`).
* Pinned dev-tool minimums (`black >= 25`, `ruff >= 0.7`, `pytest >= 8.0`, `coverage >= 7.6`, `isort >= 5.13`, `bumpver >= 2024.0`, `pip-tools >= 7.4`).
* New `CHANGELOG.md` (Keep-a-Changelog format) with the 0.0.5 entry.

## Docs
* `CHANGELOG.md` created with 0.0.5 entry.
* README unchanged (no new user-visible behavior).

## Version bump
\`0.0.4\` -> \`0.0.5\` (PyPI release on merge)