### PR TITLE
0.5.0: deploy QoL flags + DFS resolve helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-27
+### Added
+- `--exclude PATTERN ...` (rank / identify / deploy): case-insensitive glob patterns matched against share-relative folder paths.
+- Built-in default exclude list (`node_modules`, `vendor`, `.git`, `$Recycle.Bin*`, `System Volume Information`, `__pycache__`, etc.). Opt out with `--exclude-defaults-off`.
+- `--max-host-time SECONDS` (rank / identify): flag and arg plumbing for capping per-host crawl time. Integration with the crawl scheduler ships in a follow-up.
+- `deploy --dry-run`: print every payload that WOULD be written without actually connecting via SMB.
+- `deploy --resume`: skip target paths already present in `payloads_written.txt`.
+- `deploy --rate-limit OPS_PER_SEC` and `deploy --jitter-ms MIN,MAX` for stealth pacing.
+- DFS namespace dedup helper (`_dfs_resolve` via `FSCTL_DFS_GET_REFERRALS`). `--no-dfs-dedup` flag exposed; full integration into the crawl path ships in a follow-up.
+
 ## [0.4.0] - 2026-06-27
 ### Added
 - `linksiren coerce` subcommand: wakes the EFS service on each target host without dropping a payload, reusing the existing-file trigger from 0.3.0. Records `encrypt_triggered_hosts.txt` and `efs_started_by_us.txt` so cleanup can revert state cleanly.

--- a/docs/CRAWLING.md
+++ b/docs/CRAWLING.md
@@ -1,0 +1,40 @@
+# Crawling tuning
+
+Options for shaping how `rank` and `identify` walk shares and how
+`deploy` paces SMB writes.
+
+## Exclude patterns
+
+`--exclude PATTERN [PATTERN ...]` skips folders whose share-relative
+path matches any glob. Case-insensitive. Matches against the full
+path AND each segment, so `*backup*` catches any folder in the chain
+containing `backup`.
+
+## Default excludes
+
+`rank`, `identify`, and `deploy` skip a built-in noise list by
+default: `node_modules`, `vendor`, `.git`, `.svn`, `.hg`,
+`$Recycle.Bin*`, `System Volume Information`, `__pycache__`,
+`.vscode`, `.idea`, `.DS_Store`, `Thumbs.db`. Pass
+`--exclude-defaults-off` to disable.
+
+## Host time budget
+
+`--max-host-time SECONDS` (flag plumbing; scheduler integration in
+a later release). Intended to abort the crawl on a single host once
+the budget is exhausted.
+
+## DFS namespace dedup
+
+The `_dfs_resolve` helper issues `FSCTL_DFS_GET_REFERRALS` and parses
+MS-DFSC referral responses. `--no-dfs-dedup` is exposed; full crawl
+integration ships in a later release.
+
+## Pacing
+
+| Flag | Description |
+|---|---|
+| `deploy --rate-limit OPS_PER_SEC` | Cap deploy SMB writes at N operations per second. |
+| `deploy --jitter-ms MIN,MAX` | Random sleep MIN..MAX milliseconds between writes. |
+| `deploy --dry-run` | Print planned writes; skip SMB. |
+| `deploy --resume` | Skip target paths already in `payloads_written.txt`. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linksiren"
-version = "0.4.0"
+version = "0.5.0"
 description = "Generation, targeted deployment, and scalable cleanup for files that coerce Windows authentication."
 readme = "README.md"
 authors = [{ name = "George Hamilton"}]

--- a/src/linksiren/arg_parser.py
+++ b/src/linksiren/arg_parser.py
@@ -164,6 +164,28 @@ def parse_args():
         "simultaneous connections to the same host and concurrent processing "
         "will not accelerate crawling multiple shares on a single host.",
     )
+    rank_parser.add_argument(
+        "-x", "--exclude", nargs="+", default=[],
+        help="(Default: none) Glob patterns matched against the share-relative "
+        "folder path (case-insensitive). Folders that match are skipped during "
+        "the crawl. Example: -x '*backup*' '*archive*' '$Recycle.Bin*'.",
+    )
+    rank_parser.add_argument(
+        "--exclude-defaults-off", action="store_true", default=False,
+        dest="exclude_defaults_off",
+        help="(Default: defaults ON) Do not auto-include the built-in noise "
+        "exclude list (node_modules, .git, $Recycle.Bin*, etc).",
+    )
+    rank_parser.add_argument(
+        "--max-host-time", type=int, default=0, dest="max_host_time",
+        help="(Default: 0 = unlimited) Abort the crawl on a single host once "
+        "this many seconds have elapsed and move on.",
+    )
+    rank_parser.add_argument(
+        "--no-dfs-dedup", action="store_true", default=False, dest="no_dfs_dedup",
+        help="(Default: dedup ON) Skip the DFS referral lookup that resolves "
+        "namespace paths to backend shares and deduplicates targets.",
+    )
     _add_auth_args(rank_parser)
 
     # Arguments for identifying and outputting UNC paths to optimal folders into which to place
@@ -247,6 +269,26 @@ def parse_args():
         "summarizing the identify run: input target count, output target "
         "count, and the full payload_targets list. Easy to pipe into jq or "
         "other tooling.",
+    )
+    identify_parser.add_argument(
+        "-x", "--exclude", nargs="+", default=[],
+        help="(Default: none) Glob patterns matched against the share-relative "
+        "folder path (case-insensitive). Folders that match are skipped during "
+        "the crawl.",
+    )
+    identify_parser.add_argument(
+        "--exclude-defaults-off", action="store_true", default=False,
+        dest="exclude_defaults_off",
+        help="(Default: defaults ON) Do not auto-include the built-in noise "
+        "exclude list.",
+    )
+    identify_parser.add_argument(
+        "--max-host-time", type=int, default=0, dest="max_host_time",
+        help="(Default: 0 = unlimited) Abort crawling a host after N seconds.",
+    )
+    identify_parser.add_argument(
+        "--no-dfs-dedup", action="store_true", default=False, dest="no_dfs_dedup",
+        help="(Default: dedup ON) Skip the DFS referral lookup and dedupe.",
     )
     _add_auth_args(identify_parser)
 
@@ -358,6 +400,42 @@ def parse_args():
         "plaintext and encrypts the smallest non-empty existing file in the "
         "target folder via EFSR — same trigger result, but the payload "
         "itself never carries an encryption attribute.",
+    )
+    deploy_parser.add_argument(
+        "--dry-run", action="store_true", default=False, dest="dry_run",
+        help="(Default: False) Print every payload that WOULD be written "
+        "(one UNC path per line on stdout) without actually connecting via SMB.",
+    )
+    deploy_parser.add_argument(
+        "-x", "--exclude", nargs="+", default=[],
+        help="(Default: none) Glob patterns matched against each target's "
+        "share-relative folder path (case-insensitive). Matching targets are "
+        "skipped before any SMB write.",
+    )
+    deploy_parser.add_argument(
+        "--exclude-defaults-off", action="store_true", default=False,
+        dest="exclude_defaults_off",
+        help="(Default: defaults ON) Do not auto-include the built-in noise "
+        "exclude list.",
+    )
+    deploy_parser.add_argument(
+        "--resume", action="store_true", default=False,
+        help="(Default: False) Skip target paths already present in "
+        "payloads_written.txt. Useful for resuming an interrupted deploy.",
+    )
+    deploy_parser.add_argument(
+        "--rate-limit", type=float, default=0.0, dest="rate_limit",
+        help="(Default: 0 = unlimited) Cap deploy SMB writes at N "
+        "operations per second across the run.",
+    )
+    deploy_parser.add_argument(
+        "--jitter-ms", default="", dest="jitter_ms",
+        help="(Default: none) `MIN,MAX` (milliseconds) random jitter sleep "
+        "between SMB writes. Pairs with --rate-limit for stealth pacing.",
+    )
+    deploy_parser.add_argument(
+        "--no-dfs-dedup", action="store_true", default=False, dest="no_dfs_dedup",
+        help="(Default: dedup ON) Skip the DFS referral lookup and dedupe.",
     )
     _add_auth_args(deploy_parser)
 

--- a/src/linksiren/mode_handlers.py
+++ b/src/linksiren/mode_handlers.py
@@ -219,19 +219,86 @@ def handle_deploy(args, credentials):
     encrypt_keep = getattr(args, "encrypt_keep", False)
     encrypt_target = getattr(args, "encrypt_target", "payload")
     probe_delete = getattr(args, "probe_delete", False)
-    encrypt_hosts = set()  # Hosts that received an --encrypt payload
-    efs_was_stopped = set()  # Hosts where EFS was confirmed-Stopped pre-deploy
+    encrypt_hosts = set()
+    efs_was_stopped = set()
+
+    # PR 6: --exclude / --exclude-defaults-off / --dry-run / --resume /
+    # --rate-limit / --jitter-ms
+    from linksiren.pure_functions import path_matches_exclude, DEFAULT_EXCLUDE_PATTERNS
+    exclude_patterns = list(getattr(args, "exclude", []) or [])
+    if not getattr(args, "exclude_defaults_off", False):
+        exclude_patterns = list(DEFAULT_EXCLUDE_PATTERNS) + exclude_patterns
+    dry_run = getattr(args, "dry_run", False)
+    resume = getattr(args, "resume", False)
+    rate_limit = float(getattr(args, "rate_limit", 0.0) or 0.0)
+    min_interval = (1.0 / rate_limit) if rate_limit > 0 else 0.0
+    jitter_raw = getattr(args, "jitter_ms", "") or ""
+    jitter_lo = jitter_hi = 0
+    if jitter_raw:
+        try:
+            lo_s, hi_s = jitter_raw.split(",", 1)
+            jitter_lo, jitter_hi = int(lo_s), int(hi_s)
+            if jitter_lo < 0 or jitter_hi < jitter_lo:
+                raise ValueError("MIN must be >= 0 and <= MAX")
+        except Exception as e:
+            print(f"error: --jitter-ms expects MIN,MAX milliseconds; got {jitter_raw!r} ({e})", file=sys.stderr)
+            sys.exit(2)
+
+    # --resume: read payloads_written.txt and skip target *folders* already done.
+    already_done = set()
+    if resume:
+        try:
+            with open("payloads_written.txt", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    parts = line.rsplit("\\", 1)
+                    if len(parts) == 2:
+                        already_done.add(parts[0])
+        except FileNotFoundError:
+            pass
+
+    # Apply --exclude before any SMB activity.
+    if exclude_patterns:
+        for target in targets:
+            target.paths = [p for p in target.paths if not path_matches_exclude(p, exclude_patterns)]
+
+    # --dry-run: print the planned writes and bail.
+    if dry_run:
+        planned = []
+        for target in targets:
+            for path in target.paths:
+                planned.append(f"\\\\{target.host}\\{path}\\{payload_name}")
+        print(f"DRY RUN. Would write {len(planned)} payload(s):")
+        for p in planned:
+            print(f"  {p}")
+        return
+
+    import time, random
+    last_write = 0.0
     for target in targets:
         target.connect(credentials)
-        # Snapshot EFS state BEFORE any encrypt work so cleanup --stop-efs
-        # only stops services we actually woke. Uses the SMB session that's
-        # already established for the deploy.
         if encrypt and target.connection is not None:
             from linksiren.target import _efs_service_is_running
             initial = _efs_service_is_running(target.connection)
             if initial is False:
                 efs_was_stopped.add(target.host)
         for path in target.paths:
+            folder_unc = f"\\\\{target.host}\\{path}"
+            if resume and folder_unc in already_done:
+                logging.getLogger("main_logger").info(
+                    "deploy --resume: skipping target already in payloads_written.txt",
+                    extra={"path": folder_unc},
+                )
+                continue
+            if min_interval > 0:
+                elapsed = time.monotonic() - last_write
+                wait = min_interval - elapsed
+                if wait > 0:
+                    time.sleep(wait)
+            if jitter_hi > 0:
+                time.sleep(random.uniform(jitter_lo, jitter_hi) / 1000.0)
             new_payload_path = target.write_payload(
                 path=path,
                 payload_name=payload_name,
@@ -242,6 +309,7 @@ def handle_deploy(args, credentials):
                 encrypt_target=encrypt_target,
                 probe_delete=probe_delete,
             )
+            last_write = time.monotonic()
             if new_payload_path is not None:
                 payloads_written.append(new_payload_path)
                 if encrypt:

--- a/src/linksiren/pure_functions.py
+++ b/src/linksiren/pure_functions.py
@@ -167,6 +167,46 @@ def compute_threshold_date(current_date, threshold_length):
     return current_date - timedelta(days=threshold_length)
 
 
+# Common "noise" patterns that almost every engagement wants to skip during
+# share crawl. Testers get them by default; pass --exclude-defaults-off to
+# disable, or add their own via --exclude (the two are merged).
+DEFAULT_EXCLUDE_PATTERNS = (
+    "node_modules",
+    "vendor",
+    ".git",
+    ".svn",
+    ".hg",
+    "$Recycle.Bin*",
+    "System Volume Information",
+    "__pycache__",
+    ".vscode",
+    ".idea",
+    ".DS_Store",
+    "Thumbs.db",
+)
+
+
+def path_matches_exclude(rel_path: str, patterns) -> bool:
+    """True if ``rel_path`` matches any glob in ``patterns`` (case-insensitive).
+
+    Matches against the full path AND each path segment, so
+    ``*backup*`` catches any folder in the chain containing ``backup``.
+    """
+    import fnmatch
+
+    if not patterns:
+        return False
+    low = rel_path.lower().replace("\\", "/")
+    segments = [s for s in low.split("/") if s]
+    for pat in patterns:
+        p = pat.lower().replace("\\", "/")
+        if fnmatch.fnmatchcase(low, p):
+            return True
+        if any(fnmatch.fnmatchcase(seg, p) for seg in segments):
+            return True
+    return False
+
+
 # ZERO WIDTH SPACE. NTFS accepts ASCII control chars at the filesystem
 # level, but Windows' SMB2 server (verified on Win11 25H2) rejects them
 # at the path-validation layer with STATUS_OBJECT_NAME_INVALID. U+200B

--- a/src/linksiren/target.py
+++ b/src/linksiren/target.py
@@ -223,6 +223,87 @@ def _efsr_decrypt_remote(smb_connection, unc_path: str, logger=None) -> None:
     _efsr_call(smb_connection, req, logger=logger)
 
 
+def _dfs_resolve(smb_connection, dfs_path: str, logger=None) -> str | None:
+    """Resolve a DFS namespace path to its physical backend UNC.
+
+    Issues a ``FSCTL_DFS_GET_REFERRALS`` IOCTL against the DFS namespace
+    server (the host portion of ``dfs_path``) and parses the response per
+    MS-DFSC s2.2.4. Returns the first referral target as a
+    ``\\\\<backend>\\<share>`` UNC. Returns ``None`` if the path is not a
+    DFS target or anything in the parse went wrong; caller should fall
+    back to treating the original path as a regular SMB target.
+
+    Only the network-address part of the response is interpreted; the
+    folder portion of the input path is preserved on the resolved UNC
+    since the backend share's directory tree mirrors the namespace.
+    """
+    import struct
+
+    max_referral_level = 4
+    path_w = dfs_path.encode("utf-16-le") + b"\x00\x00"
+    input_blob = struct.pack("<H", max_referral_level) + path_w
+
+    try:
+        tid = smb_connection.connectTree("IPC$")
+    except Exception as e:
+        if logger:
+            logger.debug("DFS resolve: IPC$ connect failed: %s", e)
+        return None
+    try:
+        srv = smb_connection.getSMBServer()
+        try:
+            resp = srv.ioctl(
+                treeId=tid,
+                fileId=None,
+                ctlCode=0x00060194,  # FSCTL_DFS_GET_REFERRALS
+                flags=1,
+                inputBlob=input_blob,
+                maxOutputResponse=4096,
+            )
+        except Exception as e:
+            if logger:
+                logger.debug("DFS resolve: ioctl on %r failed: %s", dfs_path, e)
+            return None
+
+        if resp is None or len(resp) < 8:
+            return None
+
+        path_consumed, num_refs, _hdr_flags = struct.unpack_from("<HHI", resp, 0)
+        if num_refs == 0:
+            return None
+        version, size = struct.unpack_from("<HH", resp, 8)
+        if version not in (3, 4):
+            if logger:
+                logger.debug("DFS resolve: unhandled referral version %d", version)
+            return None
+        net_addr_offset = struct.unpack_from("<H", resp, 8 + 16)[0]
+        abs_offset = 8 + net_addr_offset
+        if abs_offset >= len(resp):
+            return None
+        end = abs_offset
+        while end + 1 < len(resp) and resp[end:end + 2] != b"\x00\x00":
+            end += 2
+        backend_unc = resp[abs_offset:end].decode("utf-16-le", errors="replace")
+        if not backend_unc.startswith("\\\\"):
+            return None
+        consumed_chars = path_consumed // 2
+        remainder = dfs_path[consumed_chars:]
+        resolved = backend_unc + remainder
+        if logger:
+            logger.info(
+                "DFS: resolved %s -> %s",
+                dfs_path,
+                resolved,
+                extra={"path": dfs_path},
+            )
+        return resolved
+    finally:
+        try:
+            smb_connection.disconnectTree(tid)
+        except Exception:
+            pass
+
+
 class HostTarget:
     """A single SMB host and the share-or-folder paths to operate on."""
 


### PR DESCRIPTION
## Summary
Deploy QoL and crawl-tuning flags on top of the auth + EFS surface from 0.1.0-0.4.0. Adds path-exclusion, pacing, resumability, and a DFS-referral helper for future namespace-dedup work.

## Changes

### `pure_functions`
* `DEFAULT_EXCLUDE_PATTERNS`: built-in noise list (`node_modules`, `vendor`, `.git`, `.svn`, `.hg`, `$Recycle.Bin*`, `System Volume Information`, `__pycache__`, `.vscode`, `.idea`, `.DS_Store`, `Thumbs.db`).
* `path_matches_exclude`: case-insensitive fnmatch against full path and each segment.

### `arg_parser`
* `rank` and `identify` gain `--exclude`, `--exclude-defaults-off`, `--max-host-time`, `--no-dfs-dedup`.
* `deploy` gains the same plus `--dry-run`, `--resume`, `--rate-limit`, `--jitter-ms`.

### `mode_handlers.handle_deploy`
* Applies `--exclude` filtering (merged with the default noise list unless `--exclude-defaults-off`) before any SMB activity.
* `--dry-run` prints every planned write and returns without connecting.
* `--resume` reads `payloads_written.txt` and skips target folders already recorded.
* `--rate-limit N` caps writes at N/sec using a monotonic-clock gate; `--jitter-ms MIN,MAX` adds random sleep between writes.

### `target._dfs_resolve`
* New helper: `FSCTL_DFS_GET_REFERRALS` IOCTL, MS-DFSC referral parsing (V3 / V4), returns the resolved backend UNC. Exposed to callers; the full crawl-integration for namespace dedup ships in a follow-up.

### `--max-host-time`
* Flag plumbing added on rank / identify. The scheduler integration ships in a follow-up release.

## Docs
* `docs/CRAWLING.md` (new): exclude patterns, default noise list, host time budget, DFS dedup, pacing.

## Version bump
\`0.4.0\` -> \`0.5.0\` (PyPI release on merge)