### PR TITLE
0.6.0: linksiren check preflight subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-27
+### Added
+- `linksiren check`: per-host preflight that reports auth result, SMB signing required, listable disk shares, EFS / WebClient service state, and per-file-type coercion viability for `.url` / `.searchConnector-ms` / `.library-ms` / `.lnk`. Output as human-readable or `--json`.
+- `_webclient_service_is_running` helper: probes `\PIPE\DAV RPC SERVICE` to determine if WebClient is up without requiring SCMR rights.
+- Fragile-infrastructure pattern flags on hostname / share-name detection (SCADA / ICS / OT / medical / safety patterns).
+
 ## [0.5.0] - 2026-06-27
 ### Added
 - `--exclude PATTERN ...` (rank / identify / deploy): case-insensitive glob patterns matched against share-relative folder paths.

--- a/docs/subcommands/check.md
+++ b/docs/subcommands/check.md
@@ -1,0 +1,23 @@
+# `linksiren check`
+
+Per-host preflight: auth result, SMB signing required, listable disk shares, EFS / WebClient state, fragile-infrastructure flags, and per-file-type coercion viability.
+
+## Usage
+
+```bash
+linksiren check -t <targets-file> [auth flags]
+linksiren check --json -t <targets-file> [auth flags] | jq .
+```
+
+## Output sections
+
+- **auth**: `ok` | `failed` | `unreached`
+- **SMB signing required**: relay-relevant boolean
+- **EFS / WebClient service state**: running / stopped / unknown via pipe-open probe
+- **shares**: file-system shares only; fragile-pattern flags appended
+- **fragile-infra hostname pattern**: SCADA, ICS, OT, medical, safety hits
+- **payload viability**: per file extension, trigger type, intranet-zone requirement, readiness
+
+## Auth
+
+All four auth methods supported. Anonymous degrades gracefully (some fields may show as `unknown` if the NULL session can't probe service state).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linksiren"
-version = "0.5.0"
+version = "0.6.0"
 description = "Generation, targeted deployment, and scalable cleanup for files that coerce Windows authentication."
 readme = "README.md"
 authors = [{ name = "George Hamilton"}]

--- a/src/linksiren/__main__.py
+++ b/src/linksiren/__main__.py
@@ -24,6 +24,7 @@ from linksiren.mode_handlers import (
     handle_deploy,
     handle_cleanup,
     handle_coerce,
+    handle_check,
 )
 
 
@@ -163,6 +164,8 @@ def main():
             handle_cleanup(args, auth)
         elif args.mode == "coerce":
             handle_coerce(args, auth)
+        elif args.mode == "check":
+            handle_check(args, auth)
     finally:
         logger.info("Terminating linksiren")
         log_queue.put(None)

--- a/src/linksiren/arg_parser.py
+++ b/src/linksiren/arg_parser.py
@@ -439,6 +439,28 @@ def parse_args():
     )
     _add_auth_args(deploy_parser)
 
+    # Arguments for preflight check.
+    check_parser = subparsers.add_parser(
+        "check",
+        description="Per-host preflight: authentication, listable shares, "
+        "EFS / WebClient service state, SMB signing-required flag, and "
+        "common fragile-infrastructure name patterns.",
+    )
+    check_required = check_parser.add_argument_group("Required Arguments")
+    check_required.add_argument(
+        "credentials", nargs="?",
+        help="[domain/]username[:password]. Omit when --anonymous is set.",
+    )
+    check_required.add_argument(
+        "-t", "--targets", required=True,
+        help="Path to a text file with UNC paths or bare hostnames to probe.",
+    )
+    check_parser.add_argument(
+        "--json", action="store_true", default=False, dest="json_output",
+        help="(Default: False) Emit a single-line JSON document on stdout.",
+    )
+    _add_auth_args(check_parser)
+
     # Arguments for the standalone EFS-coercion-trigger mode.
     coerce_parser = subparsers.add_parser(
         "coerce",

--- a/src/linksiren/mode_handlers.py
+++ b/src/linksiren/mode_handlers.py
@@ -433,6 +433,117 @@ def handle_coerce(args, credentials):
     )
 
 
+def _fmt_running(v):
+    """Compact 3-way running indicator."""
+    return {True: "running", False: "stopped", None: "unknown"}[v]
+
+
+def handle_check(args, credentials):
+    """Per-host preflight: auth, shares, service states, signing.
+
+    Reports what each target host accepts, what shares are listable,
+    EFS / WebClient service state, SMB signing-required flag, and
+    fragile-infrastructure-pattern flags on host / share names.
+    """
+    targets = read_targets(args.targets)
+    logger = logging.getLogger("main_logger")
+    from linksiren.target import _efs_service_is_running, _webclient_service_is_running
+
+    FRAGILE_PATTERNS = (
+        "scada", "ics", "plc", "rtu", "hmi", "dcs", "historian", "-ot", "ot-",
+        "medical", "biomed", "clinical", "ehr", "emr", "pacs", "hl7",
+        "infusion", "ventilator", "imaging", "lab-", "-lab",
+        "safety", "protect-", "relay-", "substation", "turbine",
+    )
+
+    def flag_fragile(name: str) -> str:
+        low = name.lower()
+        hits = [p for p in FRAGILE_PATTERNS if p in low]
+        return ",".join(hits) if hits else ""
+
+    report = []
+    for target in targets:
+        h = {
+            "host": target.host,
+            "auth": "unreached",
+            "smb_signing_required": None,
+            "shares": [],
+            "efs_running": None,
+            "webclient_running": None,
+            "fragile_hostname_flags": flag_fragile(target.host),
+        }
+        target.connect(credentials)
+        if target.connection is None:
+            h["auth"] = "failed"
+            report.append(h)
+            continue
+        h["auth"] = "ok"
+        try:
+            h["smb_signing_required"] = bool(target.connection.isSigningRequired())
+        except Exception:
+            pass
+        h["efs_running"] = _efs_service_is_running(target.connection)
+        h["webclient_running"] = _webclient_service_is_running(target.connection)
+        try:
+            from impacket.dcerpc.v5.srvs import STYPE_DISKTREE, STYPE_MASK
+            for s in target.connection.listShares():
+                if s["shi1_type"] & STYPE_MASK == STYPE_DISKTREE:
+                    name = s["shi1_netname"][:-1]
+                    h["shares"].append({"name": name, "fragile": flag_fragile(name)})
+        except Exception as e:
+            logger.warning(
+                "check: could not enumerate shares",
+                extra={"path": f"\\\\{target.host}", "exception": str(e)},
+            )
+        report.append(h)
+
+    for h in report:
+        if h["auth"] != "ok":
+            continue
+        wc = h["webclient_running"]
+        ready_wc = (
+            "yes (WebClient running)" if wc is True
+            else "yes (WebClient stopped; triggered-start expected)" if wc is False
+            else "unknown"
+        )
+        h["payload_viability"] = {
+            ".url": {"auto_trigger": False, "needs_intranet_zone": True,
+                     "ready_now": "n/a (needs user open + intranet zone)"},
+            ".searchConnector-ms": {"auto_trigger": True, "needs_intranet_zone": True, "ready_now": ready_wc},
+            ".library-ms": {"auto_trigger": True, "needs_intranet_zone": True, "ready_now": ready_wc},
+            ".lnk": {"auto_trigger": True, "needs_intranet_zone": True,
+                     "ready_now": (
+                         "yes via WebDAV (WebClient running)" if wc is True
+                         else "yes (WebClient stopped; WebDAV-first or SMB fall-through)" if wc is False
+                         else "unknown"
+                     )},
+        }
+
+    if getattr(args, "json_output", False):
+        print(json.dumps({"mode": "check", "hosts": report}))
+        return
+    for h in report:
+        print(f"\n=== {h['host']} ===")
+        print(f"  auth: {h['auth']}")
+        if h["auth"] != "ok":
+            continue
+        print(f"  SMB signing required: {h['smb_signing_required']}"
+              f"   EFS: {_fmt_running(h['efs_running'])}"
+              f"   WebClient: {_fmt_running(h['webclient_running'])}")
+        if h["fragile_hostname_flags"]:
+            print(f"  fragile-infra hostname pattern: {h['fragile_hostname_flags']}")
+        print(f"  shares ({len(h['shares'])}):")
+        for s in h["shares"]:
+            tag = f"  fragile-infra: {s['fragile']}" if s["fragile"] else ""
+            print(f"    {s['name']}{tag}")
+        print(f"  payload viability:")
+        for ext, viab in h["payload_viability"].items():
+            trig = "parent-folder open" if viab["auto_trigger"] else "user open"
+            print(f"    {ext:<22} trigger={trig:<19} intranet-zone-needed={viab['needs_intranet_zone']}")
+            print(f"    {'':<22}   ready: {viab['ready_now']}")
+    print()
+
+
 def handle_cleanup(args, credentials):
     """
     Handles the cleanup process by connecting to each target and deleting specified payloads.

--- a/src/linksiren/target.py
+++ b/src/linksiren/target.py
@@ -223,6 +223,45 @@ def _efsr_decrypt_remote(smb_connection, unc_path: str, logger=None) -> None:
     _efsr_call(smb_connection, req, logger=logger)
 
 
+def _webclient_service_is_running(smb_connection, logger=None) -> bool | None:
+    """Probe whether the WebClient service is running on the SMB host.
+
+    HTTP coercion via .searchConnector-ms / .library-ms payloads needs the
+    WebClient service running (it's the service that turns ``http://...``
+    references in those files into actual SMB-via-HTTP auth requests). The
+    service exposes ``\\PIPE\\DAV RPC SERVICE`` while running, so the same
+    pipe-open probe pattern that works for EFS works here.
+
+    Returns: True (running), False (Stopped), None (ambiguous).
+    """
+    try:
+        tid = smb_connection.connectTree("IPC$")
+    except Exception as e:
+        if logger:
+            logger.debug("WebClient probe: IPC$ tree connect failed: %s", e)
+        return None
+    try:
+        try:
+            fid = smb_connection.openFile(tid, r"\DAV RPC SERVICE")
+            try:
+                smb_connection.closeFile(tid, fid)
+            except Exception:
+                pass
+            return True
+        except Exception as e:
+            err = str(e)
+            if "STATUS_OBJECT_NAME_NOT_FOUND" in err or "STATUS_OBJECT_PATH_NOT_FOUND" in err:
+                return False
+            if logger:
+                logger.debug("WebClient probe: ambiguous openFile error: %s", e)
+            return None
+    finally:
+        try:
+            smb_connection.disconnectTree(tid)
+        except Exception:
+            pass
+
+
 def _dfs_resolve(smb_connection, dfs_path: str, logger=None) -> str | None:
     """Resolve a DFS namespace path to its physical backend UNC.
 


### PR DESCRIPTION
## Summary
Adds `linksiren check`: a per-host preflight subcommand that reports auth result, SMB signing, listable disk shares, EFS / WebClient service state, fragile-infrastructure name flags, and per-file-type coercion viability. Meant to be run before deploy so you know which targets are actually viable for which attack.

## Changes
* **`target._webclient_service_is_running`**: probes `\PIPE\DAV RPC SERVICE` to determine if WebClient is up. Mirrors the shape of `_efs_service_is_running`. Return: `True` (running), `False` (Stopped), `None` (probe inconclusive).
* **`arg_parser`**: new `check` subparser with `-t / --targets`, `--json`, and the shared auth flags.
* **`mode_handlers.handle_check`**: connects to each target, reports auth outcome; for reached hosts reports `isSigningRequired`, EFS state, WebClient state, listable disk shares, and fragile-infrastructure pattern flags on hostname / share names (SCADA / ICS / OT / medical / safety patterns). Builds a per-file-type viability matrix (`.url`, `.searchConnector-ms`, `.library-ms`, `.lnk`) with trigger conditions and readiness. Human-readable output by default, `--json` for structured consumption.
* **`mode_handlers._fmt_running`**: 3-way running / stopped / unknown indicator used by the check output.
* **`__main__` dispatch** for the `check` mode.

## Docs
* `docs/subcommands/check.md` (new).

## Version bump
\`0.5.0\` -> \`0.6.0\` (PyPI release on merge)