### PR TITLE
0.7.0: linksiren discover (LDAP-based target discovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-27
+### Added
+- `linksiren discover`: enumerate computer objects from Active Directory via LDAP. Filters disabled accounts; optional `--inactive-days N` drops dormant hosts. Emits one `\\<dnsHostName>` UNC per line (or bare hostnames with `--hostname-only`). Supports `--ldaps`, `--base-dn`, `-o PATH`, `--json`.
+
 ## [0.6.0] - 2026-06-27
 ### Added
 - `linksiren check`: per-host preflight that reports auth result, SMB signing required, listable disk shares, EFS / WebClient service state, and per-file-type coercion viability for `.url` / `.searchConnector-ms` / `.library-ms` / `.lnk`. Output as human-readable or `--json`.

--- a/docs/subcommands/discover.md
+++ b/docs/subcommands/discover.md
@@ -1,0 +1,26 @@
+# `linksiren discover`
+
+Enumerate computer objects from Active Directory via LDAP. Output is a targets file ready for `rank` / `identify` / `coerce`.
+
+## Usage
+
+```bash
+linksiren discover [domain/]user:password -dc-ip <kdc-or-fqdn> [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--base-dn` | derived from `credentials.domain` | LDAP search base. |
+| `--ldaps` | off | Use LDAPS (636) instead of LDAP (389). |
+| `--inactive-days N` | 0 (off) | Drop computers whose `lastLogonTimestamp` is older than N days. |
+| `--hostname-only` | off | Output bare hostnames instead of `\\host` UNCs. |
+| `-o PATH` | stdout only | Write to file in addition to stdout. |
+| `--json` | off | Structured output. |
+
+Disabled accounts (`userAccountControl` bit 2 set) are always filtered out.
+
+## Auth
+
+NTLM password, PtH, Kerberos. Anonymous LDAP binds are typically refused by modern AD.
+
+When `-k` is used with an IP-form `-dc-ip`, linksiren reverse-DNSes the IP to an FQDN for the `ldap/<host>` SPN; if reverse DNS fails it logs a warning and the tester is expected to pass `--dc-ip <fqdn>` explicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linksiren"
-version = "0.6.0"
+version = "0.7.0"
 description = "Generation, targeted deployment, and scalable cleanup for files that coerce Windows authentication."
 readme = "README.md"
 authors = [{ name = "George Hamilton"}]

--- a/src/linksiren/__main__.py
+++ b/src/linksiren/__main__.py
@@ -25,6 +25,7 @@ from linksiren.mode_handlers import (
     handle_cleanup,
     handle_coerce,
     handle_check,
+    handle_discover,
 )
 
 
@@ -166,6 +167,8 @@ def main():
             handle_coerce(args, auth)
         elif args.mode == "check":
             handle_check(args, auth)
+        elif args.mode == "discover":
+            handle_discover(args, auth)
     finally:
         logger.info("Terminating linksiren")
         log_queue.put(None)

--- a/src/linksiren/arg_parser.py
+++ b/src/linksiren/arg_parser.py
@@ -439,6 +439,45 @@ def parse_args():
     )
     _add_auth_args(deploy_parser)
 
+    # Arguments for AD computer discovery via LDAP.
+    discover_parser = subparsers.add_parser(
+        "discover",
+        description="Enumerate computer objects from Active Directory via "
+        "LDAP and emit a targets file usable by rank / identify / coerce. "
+        "Filters disabled accounts; optional --inactive-days trims dormant.",
+    )
+    discover_required = discover_parser.add_argument_group("Required Arguments")
+    discover_required.add_argument(
+        "credentials", nargs="?",
+        help="[domain/]username[:password] for LDAP bind.",
+    )
+    discover_parser.add_argument(
+        "--base-dn", dest="base_dn",
+        help="Base DN. Derived from credentials.domain when omitted.",
+    )
+    discover_parser.add_argument(
+        "--ldaps", action="store_true", default=False,
+        help="(Default: False) Use LDAPS (636) instead of LDAP (389).",
+    )
+    discover_parser.add_argument(
+        "--inactive-days", type=int, default=0, dest="inactive_days",
+        help="(Default: 0 = off) Drop computers whose lastLogonTimestamp is "
+        "older than N days.",
+    )
+    discover_parser.add_argument(
+        "--hostname-only", action="store_true", default=False, dest="hostname_only",
+        help="(Default: emit \\\\hostname) Emit bare hostnames.",
+    )
+    discover_parser.add_argument(
+        "-o", "--output",
+        help="(Default: stdout only) Write to this file in addition to stdout.",
+    )
+    discover_parser.add_argument(
+        "--json", action="store_true", default=False, dest="json_output",
+        help="(Default: False) Emit JSON results.",
+    )
+    _add_auth_args(discover_parser)
+
     # Arguments for preflight check.
     check_parser = subparsers.add_parser(
         "check",

--- a/src/linksiren/mode_handlers.py
+++ b/src/linksiren/mode_handlers.py
@@ -433,6 +433,122 @@ def handle_coerce(args, credentials):
     )
 
 
+def handle_discover(args, credentials):
+    """Enumerate computer objects from AD via LDAP; emit a targets file.
+
+    Output one ``\\\\<dnsHostName>`` UNC per line (or bare hostnames with
+    ``--hostname-only``). Disabled accounts are always filtered out;
+    ``--inactive-days N`` drops machines whose ``lastLogonTimestamp`` is
+    older than N days.
+    """
+    from impacket.ldap import ldap, ldapasn1
+
+    dc_ip = getattr(args, "dc_ip", None) or credentials.domain
+    if not dc_ip:
+        print("error: --dc-ip is required (no domain inferred from credentials).", file=sys.stderr)
+        sys.exit(2)
+
+    logger = logging.getLogger("main_logger")
+    if credentials.use_kerberos:
+        import ipaddress, socket
+        try:
+            ipaddress.ip_address(dc_ip)
+            try:
+                primary, aliases, _ = socket.gethostbyaddr(dc_ip)
+                candidates = [n for n in [primary] + list(aliases) if "." in n]
+                if candidates:
+                    dc_ip = candidates[0]
+                    logger.info("discover: -k with IP-form -dc-ip; resolved to %s for the ldap SPN.", dc_ip, extra={"path": None})
+            except (socket.herror, socket.gaierror) as e:
+                logger.warning("discover: -k with IP -dc-ip and reverse DNS failed (%s).", e, extra={"path": None})
+        except ValueError:
+            pass
+
+    base_dn = getattr(args, "base_dn", None)
+    if not base_dn:
+        if not credentials.domain or "." not in credentials.domain:
+            print("error: --base-dn required when credentials domain is not an FQDN.", file=sys.stderr)
+            sys.exit(2)
+        base_dn = ",".join(f"DC={p}" for p in credentials.domain.split("."))
+
+    use_ldaps = getattr(args, "ldaps", False)
+    target = f"{'ldaps' if use_ldaps else 'ldap'}://{dc_ip}"
+    conn = ldap.LDAPConnection(target, base_dn, dc_ip)
+    if credentials.use_kerberos:
+        conn.kerberosLogin(
+            credentials.username, credentials.password, credentials.domain,
+            getattr(credentials, "lmhash", ""), getattr(credentials, "nthash", ""),
+            getattr(credentials, "aes_key", ""),
+            kdcHost=getattr(credentials, "kdc_host", None), useCache=True,
+        )
+    else:
+        conn.login(
+            credentials.username, credentials.password, credentials.domain,
+            getattr(credentials, "lmhash", ""), getattr(credentials, "nthash", ""),
+        )
+
+    search_filter = "(&(objectClass=computer)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))"
+    attrs = ["dNSHostName", "sAMAccountName", "operatingSystem", "lastLogonTimestamp"]
+    raw = conn.search(searchFilter=search_filter, attributes=attrs, sizeLimit=0)
+
+    inactive_days = int(getattr(args, "inactive_days", 0) or 0)
+    cutoff_filetime = 0
+    if inactive_days > 0:
+        import time
+        seconds_cutoff = time.time() - (inactive_days * 86400)
+        cutoff_filetime = int((seconds_cutoff + 11644473600) * 10_000_000)
+
+    hosts = []
+    for entry in raw:
+        if not isinstance(entry, ldapasn1.SearchResultEntry):
+            continue
+        host = sam = os_ = None
+        last_logon = 0
+        for attr in entry["attributes"]:
+            name = str(attr["type"])
+            vals = [str(v) for v in attr["vals"]]
+            if not vals:
+                continue
+            if name == "dNSHostName":
+                host = vals[0]
+            elif name == "sAMAccountName":
+                sam = vals[0]
+            elif name == "operatingSystem":
+                os_ = vals[0]
+            elif name == "lastLogonTimestamp":
+                try:
+                    last_logon = int(vals[0])
+                except ValueError:
+                    pass
+        if not host and sam and sam.endswith("$") and credentials.domain:
+            host = sam[:-1] + "." + credentials.domain.lower()
+        if not host:
+            continue
+        if cutoff_filetime and last_logon and last_logon < cutoff_filetime:
+            continue
+        hosts.append({"host": host, "os": os_ or "", "last_logon_filetime": last_logon})
+
+    hostname_only = getattr(args, "hostname_only", False)
+    out_path = getattr(args, "output", None)
+    out_lines = [h["host"] if hostname_only else f"\\\\{h['host']}" for h in hosts]
+
+    if getattr(args, "json_output", False):
+        print(json.dumps({
+            "mode": "discover", "base_dn": base_dn, "dc": dc_ip,
+            "computer_count": len(hosts), "computers": hosts,
+        }))
+    else:
+        for line in out_lines:
+            print(line)
+        print(f"# {len(out_lines)} computer(s) discovered", file=sys.stderr)
+
+    if out_path:
+        with open(out_path, "w", encoding="utf-8") as f:
+            for line in out_lines:
+                f.write(line + "\n")
+        print(f"# wrote {out_path}", file=sys.stderr)
+
+
 def _fmt_running(v):
     """Compact 3-way running indicator."""
     return {True: "running", False: "stopped", None: "unknown"}[v]


### PR DESCRIPTION
## Summary
Adds `linksiren discover`: enumerate computer objects from Active Directory via LDAP and emit a targets file usable by every other credentialed subcommand.

## Changes

### `arg_parser`
* New `discover` subparser with `--base-dn`, `--ldaps`, `--inactive-days`, `--hostname-only`, `-o / --output`, `--json`, and the shared auth flags.

### `mode_handlers.handle_discover`
* Derives the LDAP `base-DN` from `credentials.domain` (e.g. `acme.local` -> `DC=acme,DC=local`) unless `--base-dn` is supplied.
* When `-k` is used with an IP-form `-dc-ip`, reverse-DNS resolves it to an FQDN so the `ldap/<host>` SPN can be located; a warning is logged if reverse DNS fails.
* Bind honors NTLM password, Pass-the-Hash, Kerberos (ccache), and anonymous per the shared `AuthContext`.
* Filters out disabled machine accounts via the OID-extensible bitmask filter (`userAccountControl:1.2.840.113556.1.4.803:=2`).
* Optional `--inactive-days N` drops computers whose `lastLogonTimestamp` is older than N days (converted to Windows FILETIME for the comparison).
* Emits one `\\<dnsHostName>` UNC per line by default; `--hostname-only` emits bare hostnames; `-o PATH` writes to file in addition to stdout; `--json` emits a structured document.

### `__main__` dispatch
* New `discover` mode.

## Docs
* `docs/subcommands/discover.md` (new).

## Version bump
\`0.6.0\` -> \`0.7.0\` (PyPI release on merge)